### PR TITLE
feat(ci): add GitHub Actions workflow to build and upload Windows setup.exe

### DIFF
--- a/.github/workflows/build-windows-setup.yml
+++ b/.github/workflows/build-windows-setup.yml
@@ -1,0 +1,79 @@
+name: Build Windows Setup
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-windows-setup:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Windows app
+        run: flutter build windows --release
+
+      - name: Prepare Inno Setup script
+        shell: pwsh
+        run: |
+          $appName = "ushio-md"
+          $pubspec = Get-Content pubspec.yaml -Raw
+          if ($pubspec -match "(?m)^version:\s*([^\s+]+)") {
+            $appVersion = $Matches[1]
+          } else {
+            $appVersion = "0.0.0"
+          }
+
+          $releaseDir = (Resolve-Path "build/windows/x64/runner/Release").Path
+          $iss = @"
+          [Setup]
+          AppId={{4D779D85-9C34-4D4F-AF74-A72A6AB90C85}
+          AppName=$appName
+          AppVersion=$appVersion
+          DefaultDirName={autopf}\\$appName
+          DefaultGroupName=$appName
+          OutputDir=installer
+          OutputBaseFilename=$appName-$appVersion-setup
+          Compression=lzma
+          SolidCompression=yes
+          WizardStyle=modern
+
+          [Files]
+          Source: "$releaseDir\\*"; DestDir: "{app}"; Flags: recursesubdirs ignoreversion
+
+          [Icons]
+          Name: "{group}\\$appName"; Filename: "{app}\\mdreader.exe"
+          Name: "{autodesktop}\\$appName"; Filename: "{app}\\mdreader.exe"; Tasks: desktopicon
+
+          [Tasks]
+          Name: "desktopicon"; Description: "Create a desktop icon"; GroupDescription: "Additional icons:";
+
+          [Run]
+          Filename: "{app}\\mdreader.exe"; Description: "Launch $appName"; Flags: nowait postinstall skipifsilent
+          "@
+
+          Set-Content -Path "windows_installer.iss" -Value $iss -Encoding UTF8
+
+      - name: Build setup.exe
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+        with:
+          path: windows_installer.iss
+
+      - name: Upload setup artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-setup
+          path: installer/*.exe
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Provide an automated GitHub Actions workflow to build a Windows installer for the Flutter app and publish it as a workflow artifact.
- Ensure the installer is versioned from `pubspec.yaml` and bundles the Windows release output into a single `setup.exe` for distribution.
- Allow releases to be produced either manually or by pushing a `v*` tag.

### Description
- Add `.github/workflows/build-windows-setup.yml` that runs on `windows-latest` and triggers on `workflow_dispatch` and tag pushes matching `v*`.
- Steps include checking out the repo, setting up Flutter via `subosito/flutter-action@v2`, running `flutter pub get`, and building `flutter build windows --release`.
- The workflow dynamically generates an Inno Setup script (reads `version` from `pubspec.yaml`), targets `build/windows/x64/runner/Release`, and expects the app executable name `mdreader.exe` in the bundle.
- It compiles `setup.exe` with `Minionguyjpro/Inno-Setup-Action@v1.2.5` and uploads the produced installer(s) as the `windows-setup` artifact via `actions/upload-artifact@v4`.

### Testing
- No automated tests were executed as part of this change; the added workflow will run in GitHub Actions when triggered manually or by pushing a `v*` tag.
- The workflow file was created and validated locally for syntax and committed to the repository.
- To validate end-to-end, trigger the workflow with `workflow_dispatch` or push a `vX.Y.Z` tag in the repository to let GitHub Actions build and upload the installer.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a298f920948329b361e25160a8e57e)