### PR TITLE
feat: add switchable app button styles

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'plugins/extensions/theme_extension.dart';
 import 'screens/main_screen.dart';
 import 'services/font_service.dart';
 import 'services/my_files_service.dart';
+import 'utils/app_style.dart';
 import 'utils/constants.dart';
 
 /// ============================================================================
@@ -137,8 +138,8 @@ class MyApp extends StatelessWidget {
               Locale('en', 'US'),  // 英文
             ],
             locale: settings.locale,  // 使用动态语言设置
-            theme: _buildLightTheme(primaryColor, fontFamily, lightThemeIndex, pluginLightColors),  // 浅色主题
-            darkTheme: _buildDarkTheme(primaryColor, darkThemeIndex, fontFamily, pluginDarkColors),  // 深色主题
+            theme: _buildLightTheme(primaryColor, fontFamily, lightThemeIndex, settings.buttonStyleMode, pluginLightColors),  // 浅色主题
+            darkTheme: _buildDarkTheme(primaryColor, darkThemeIndex, fontFamily, settings.buttonStyleMode, pluginDarkColors),  // 深色主题
             themeMode: settings.themeMode,  // 主题模式（跟随系统/浅色/深色）
             home: const MainScreen(),  // 主页面
           );
@@ -152,102 +153,35 @@ class MyApp extends StatelessWidget {
   /// [primaryColor] 用户选择的主题色
   /// [fontFamily] 用户选择的字体（null 表示系统默认）
   /// [pluginColors] 插件自定义颜色
-  ThemeData _buildLightTheme(Color primaryColor, String? fontFamily, int lightThemeIndex, ThemeColors? pluginColors) {
-    // 获取选中的浅色主题配色方案
+  ThemeData _buildLightTheme(
+    Color primaryColor,
+    String? fontFamily,
+    int lightThemeIndex,
+    AppButtonStyleMode buttonStyleMode,
+    ThemeColors? pluginColors,
+  ) {
     final scheme = AppConstants.lightThemeSchemes[lightThemeIndex];
-    
-    // 构建基础 ColorScheme
+
     var colorScheme = ColorScheme.light(
       primary: primaryColor,
       secondary: AppConstants.accentColor,
       surface: scheme.surface,
       error: AppConstants.errorColor,
     );
-    
-    // 应用插件颜色覆盖
+
     if (pluginColors != null) {
       colorScheme = pluginColors.applyTo(colorScheme);
     }
-    
-    // 构建基础主题
-    ThemeData theme = ThemeData(
-      useMaterial3: true,  // 启用 Material 3 设计
+
+    return _buildTheme(
       brightness: Brightness.light,
       colorScheme: colorScheme,
-      scaffoldBackgroundColor: scheme.background,
-      
-      // AppBar 主题
-      appBarTheme: AppBarTheme(
-        backgroundColor: scheme.surface,
-        foregroundColor: scheme.text,
-        elevation: 0,  // 无阴影
-        centerTitle: false,  // 标题左对齐
-      ),
-      
-      // 卡片主题
-      cardTheme: CardThemeData(
-        color: scheme.surface,
-        elevation: 0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppConstants.borderRadius),
-          side: BorderSide(color: scheme.textSecondary.withValues(alpha: 0.2)),
-        ),
-      ),
-      
-      // 浮动按钮主题
-      floatingActionButtonTheme: FloatingActionButtonThemeData(
-        backgroundColor: primaryColor,
-        foregroundColor: Colors.white,
-      ),
-      
-      // 输入框主题
-      inputDecorationTheme: InputDecorationTheme(
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(AppConstants.borderRadiusSmall),
-        ),
-        filled: true,
-        fillColor: scheme.background,
-      ),
-      
-      // 分割线主题
-      dividerTheme: DividerThemeData(
-        color: scheme.textSecondary.withValues(alpha: 0.2),
-        thickness: 1,
-      ),
-      
-      // 下拉菜单主题
-      dropdownMenuTheme: DropdownMenuThemeData(
-        textStyle: TextStyle(color: scheme.text),
-        menuStyle: MenuStyle(
-          backgroundColor: WidgetStatePropertyAll(scheme.surface),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-            ),
-          ),
-          elevation: const WidgetStatePropertyAll(8),
-          padding: const WidgetStatePropertyAll(EdgeInsets.all(8)),
-        ),
-      ),
-      
-      // 弹出菜单主题
-      popupMenuTheme: PopupMenuThemeData(
-        color: scheme.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        elevation: 8,
-      ),
+      backgroundColor: scheme.background,
+      textColor: scheme.text,
+      textSecondaryColor: scheme.textSecondary,
+      fontFamily: fontFamily,
+      buttonStyleMode: buttonStyleMode,
     );
-    
-    // 应用字体
-    if (fontFamily != null) {
-      theme = theme.copyWith(
-        textTheme: theme.textTheme.apply(fontFamily: fontFamily),
-      );
-    }
-    
-    return theme;
   }
 
   /// 构建深色主题
@@ -256,109 +190,218 @@ class MyApp extends StatelessWidget {
   /// [darkThemeIndex] 夜间主题配色方案索引
   /// [fontFamily] 用户选择的字体（null 表示系统默认）
   /// [pluginColors] 插件自定义颜色
-  ThemeData _buildDarkTheme(Color primaryColor, int darkThemeIndex, String? fontFamily, ThemeColors? pluginColors) {
-    // 获取选中的夜间主题配色方案
+  ThemeData _buildDarkTheme(
+    Color primaryColor,
+    int darkThemeIndex,
+    String? fontFamily,
+    AppButtonStyleMode buttonStyleMode,
+    ThemeColors? pluginColors,
+  ) {
     final scheme = AppConstants.darkThemeSchemes[darkThemeIndex];
-    
-    // 构建基础 ColorScheme
+
     var colorScheme = ColorScheme.dark(
       primary: primaryColor,
       secondary: AppConstants.accentColor,
       surface: scheme.surface,
       error: AppConstants.errorColor,
     );
-    
-    // 应用插件颜色覆盖
+
     if (pluginColors != null) {
       colorScheme = pluginColors.applyTo(colorScheme);
     }
-    
-    // 构建基础主题
-    ThemeData theme = ThemeData(
-      useMaterial3: true,
+
+    return _buildTheme(
       brightness: Brightness.dark,
       colorScheme: colorScheme,
-      scaffoldBackgroundColor: scheme.background,
-      
+      backgroundColor: scheme.background,
+      textColor: scheme.text,
+      textSecondaryColor: scheme.textSecondary,
+      fontFamily: fontFamily,
+      buttonStyleMode: buttonStyleMode,
+    );
+  }
+
+  ThemeData _buildTheme({
+    required Brightness brightness,
+    required ColorScheme colorScheme,
+    required Color backgroundColor,
+    required Color textColor,
+    required Color textSecondaryColor,
+    required String? fontFamily,
+    required AppButtonStyleMode buttonStyleMode,
+  }) {
+    final appStyle = AppStyleTheme.resolve(
+      brightness: brightness,
+      colorScheme: colorScheme,
+      textSecondary: textSecondaryColor,
+      buttonStyleMode: buttonStyleMode,
+    );
+
+    final buttonForeground = appStyle.useBorderlessButtons
+        ? textColor
+        : Colors.white;
+    final buttonBackground = appStyle.useBorderlessButtons
+        ? appStyle.strongSurface
+        : colorScheme.primary;
+
+    ThemeData theme = ThemeData(
+      useMaterial3: true,
+      brightness: brightness,
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: backgroundColor,
+      extensions: [appStyle],
       appBarTheme: AppBarTheme(
-        backgroundColor: scheme.surface,
-        foregroundColor: scheme.text,
+        backgroundColor: colorScheme.surface,
+        foregroundColor: textColor,
         elevation: 0,
         centerTitle: false,
       ),
-      
       cardTheme: CardThemeData(
-        color: scheme.surface,
-        elevation: 0,
+        color: colorScheme.surface,
+        elevation: appStyle.useBorderlessButtons ? 4 : 0,
+        shadowColor: Colors.black.withValues(alpha: 0.14),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppConstants.borderRadius),
-          side: BorderSide(color: scheme.textSecondary.withValues(alpha: 0.3)),
-
+          side: BorderSide(
+            color: appStyle.useBorderlessButtons
+                ? Colors.transparent
+                : textSecondaryColor.withValues(alpha: brightness == Brightness.dark ? 0.3 : 0.2),
+          ),
         ),
       ),
-      
-      floatingActionButtonTheme: FloatingActionButtonThemeData(
-        backgroundColor: primaryColor,
-        foregroundColor: Colors.white,
-      ),
-      
-      inputDecorationTheme: InputDecorationTheme(
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(AppConstants.borderRadiusSmall),
-        ),
-        filled: true,
-        fillColor: scheme.background,
-      ),
-      
-      dividerTheme: DividerThemeData(
-        color: scheme.textSecondary.withValues(alpha: 0.3),
-
-        thickness: 1,
-      ),
-      
-      // 文本主题（使用夜间主题配色）
-      textTheme: TextTheme(
-        bodyLarge: TextStyle(color: scheme.text),
-        bodyMedium: TextStyle(color: scheme.text),
-        bodySmall: TextStyle(color: scheme.textSecondary),
-        titleLarge: TextStyle(color: scheme.text),
-        titleMedium: TextStyle(color: scheme.text),
-        titleSmall: TextStyle(color: scheme.textSecondary),
-      ),
-      
-      // 下拉菜单主题
-      dropdownMenuTheme: DropdownMenuThemeData(
-        textStyle: TextStyle(color: scheme.text),
-        menuStyle: MenuStyle(
-          backgroundColor: WidgetStatePropertyAll(scheme.surface),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          foregroundColor: buttonForeground,
+          backgroundColor: buttonBackground,
+          disabledBackgroundColor: buttonBackground.withValues(alpha: 0.45),
+          disabledForegroundColor: buttonForeground.withValues(alpha: 0.55),
+          elevation: appStyle.useBorderlessButtons ? 4 : 0,
+          shadowColor: Colors.black.withValues(alpha: 0.18),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+            side: BorderSide(
+              color: appStyle.useBorderlessButtons ? Colors.transparent : colorScheme.primary,
             ),
           ),
-          elevation: const WidgetStatePropertyAll(8),
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+        ).copyWith(
+          overlayColor: WidgetStatePropertyAll(colorScheme.primary.withValues(alpha: 0.08)),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: appStyle.useBorderlessButtons ? textColor : colorScheme.primary,
+          backgroundColor: appStyle.useBorderlessButtons ? appStyle.strongSurface : Colors.transparent,
+          side: BorderSide(
+            color: appStyle.useBorderlessButtons ? Colors.transparent : appStyle.outlineColor,
+          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          foregroundColor: buttonForeground,
+          backgroundColor: buttonBackground,
+          elevation: appStyle.useBorderlessButtons ? 4 : 0,
+          shadowColor: Colors.black.withValues(alpha: 0.18),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+            side: BorderSide(
+              color: appStyle.useBorderlessButtons ? Colors.transparent : colorScheme.primary,
+            ),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: appStyle.useBorderlessButtons ? textColor : colorScheme.primary,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        ),
+      ),
+      iconButtonTheme: IconButtonThemeData(
+        style: IconButton.styleFrom(
+          foregroundColor: textColor,
+          backgroundColor: appStyle.useBorderlessButtons ? appStyle.strongSurface : null,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        ),
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: buttonBackground,
+        foregroundColor: buttonForeground,
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: appStyle.useBorderlessButtons ? appStyle.mutedSurface : backgroundColor,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        border: _buildInputBorder(appStyle, textSecondaryColor),
+        enabledBorder: _buildInputBorder(appStyle, textSecondaryColor),
+        focusedBorder: _buildInputBorder(appStyle, colorScheme.primary),
+      ),
+      dividerTheme: DividerThemeData(
+        color: textSecondaryColor.withValues(alpha: appStyle.useBorderlessButtons ? 0.1 : brightness == Brightness.dark ? 0.3 : 0.2),
+        thickness: 1,
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: colorScheme.surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: colorScheme.surface,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+      ),
+      popupMenuTheme: PopupMenuThemeData(
+        color: colorScheme.surface,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        elevation: appStyle.useBorderlessButtons ? 0 : 8,
+      ),
+      dropdownMenuTheme: DropdownMenuThemeData(
+        textStyle: TextStyle(color: textColor),
+        menuStyle: MenuStyle(
+          backgroundColor: WidgetStatePropertyAll(colorScheme.surface),
+          shape: WidgetStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          ),
+          elevation: WidgetStatePropertyAll(appStyle.useBorderlessButtons ? 0 : 8),
           padding: const WidgetStatePropertyAll(EdgeInsets.all(8)),
         ),
       ),
-      
-      // 弹出菜单主题
-      popupMenuTheme: PopupMenuThemeData(
-        color: scheme.surface,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12),
-        ),
-        elevation: 8,
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        backgroundColor: colorScheme.surface,
+        contentTextStyle: TextStyle(color: textColor),
+      ),
+      textTheme: TextTheme(
+        bodyLarge: TextStyle(color: textColor),
+        bodyMedium: TextStyle(color: textColor),
+        bodySmall: TextStyle(color: textSecondaryColor),
+        titleLarge: TextStyle(color: textColor),
+        titleMedium: TextStyle(color: textColor),
+        titleSmall: TextStyle(color: textSecondaryColor),
       ),
     );
-    
-    // 应用字体
+
     if (fontFamily != null) {
       theme = theme.copyWith(
         textTheme: theme.textTheme.apply(fontFamily: fontFamily),
       );
     }
-    
+
     return theme;
+  }
+
+  OutlineInputBorder _buildInputBorder(AppStyleTheme appStyle, Color color) {
+    return OutlineInputBorder(
+      borderRadius: BorderRadius.circular(AppConstants.borderRadiusSmall),
+      borderSide: BorderSide(
+        color: appStyle.useBorderlessButtons ? Colors.transparent : color,
+      ),
+    );
   }
 }
 

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -17,6 +17,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../utils/app_style.dart';
+
 /// 设置状态提供者
 ///
 /// 管理应用的外观和行为设置
@@ -44,6 +46,9 @@ class SettingsProvider extends ChangeNotifier {
 
   /// UI 字体族（System 表示系统默认）
   String _uiFontFamily = 'System';
+
+  /// 按钮风格（经典描边 / 简洁立体）
+  AppButtonStyleMode _buttonStyleMode = AppButtonStyleMode.classic;
 
   /// 编辑器字体族
   String _editorFontFamily = 'System';
@@ -212,6 +217,8 @@ class SettingsProvider extends ChangeNotifier {
   int get darkThemeIndex => _darkThemeIndex;
   int get lightThemeIndex => _lightThemeIndex;
   String get uiFontFamily => _uiFontFamily;
+  AppButtonStyleMode get buttonStyleMode => _buttonStyleMode;
+  bool get useBorderlessButtons => _buttonStyleMode == AppButtonStyleMode.softShadow;
   String get editorFontFamily => _editorFontFamily;
   String get codeFontFamily => _codeFontFamily;
 
@@ -340,6 +347,12 @@ class SettingsProvider extends ChangeNotifier {
     // 夜间主题和字体设置
     _darkThemeIndex = prefs.getInt('dark_theme_index') ?? 0;
     _lightThemeIndex = prefs.getInt('light_theme_index') ?? 0;
+
+    final buttonStyleName = prefs.getString('button_style_mode');
+    _buttonStyleMode = AppButtonStyleMode.values.firstWhere(
+      (mode) => mode.name == buttonStyleName,
+      orElse: () => AppButtonStyleMode.classic,
+    );
 
     // 字体设置迁移逻辑
     final oldFontFamily = prefs.getString('font_family');
@@ -673,6 +686,14 @@ class SettingsProvider extends ChangeNotifier {
     _lightThemeIndex = index;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt('light_theme_index', index);
+    notifyListeners();
+  }
+
+  /// 设置按钮风格
+  Future<void> setButtonStyleMode(AppButtonStyleMode mode) async {
+    _buttonStyleMode = mode;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('button_style_mode', mode.name);
     notifyListeners();
   }
 

--- a/lib/screens/editor/components/editor_header.dart
+++ b/lib/screens/editor/components/editor_header.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../../../utils/app_style.dart';
+
 class EditorHeader extends StatelessWidget {
   final String fileName;
   final String wordCount;
@@ -26,22 +28,9 @@ class EditorHeader extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(8, 8, 16, 8),
       child: Row(
         children: [
-          IconButton(
-            icon: Container(
-              padding: const EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-                ),
-              ),
-              child: Icon(
-                Icons.arrow_back,
-                size: 20,
-                color: Theme.of(context).colorScheme.onSurface,
-              ),
-            ),
+          _buildHeaderIconButton(
+            context,
+            icon: Icons.arrow_back,
             onPressed: onBack,
           ),
           const SizedBox(width: 8),
@@ -91,23 +80,10 @@ class EditorHeader extends StatelessWidget {
           _buildSaveButton(context),
           if (onMore != null) ...[
             const SizedBox(width: 8),
-            IconButton(
-              icon: Container(
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-                  ),
-                ),
-                child: Icon(
-                  Icons.more_vert,
-                  size: 20,
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
-              ),
-              onPressed: onMore,
+            _buildHeaderIconButton(
+              context,
+              icon: Icons.more_vert,
+              onPressed: onMore!,
             ),
           ],
         ],
@@ -115,7 +91,33 @@ class EditorHeader extends StatelessWidget {
     );
   }
 
+  Widget _buildHeaderIconButton(
+    BuildContext context, {
+    required IconData icon,
+    required VoidCallback onPressed,
+  }) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onPressed,
+      child: Container(
+        padding: const EdgeInsets.all(10),
+        decoration: appStyle.surfaceDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.82),
+          prominent: appStyle.useBorderlessButtons,
+        ),
+        child: Icon(
+          icon,
+          size: 20,
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+
   Widget _buildSaveButton(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       decoration: BoxDecoration(
         gradient: isModified
@@ -126,22 +128,16 @@ class EditorHeader extends StatelessWidget {
                 ],
               )
             : null,
-        color: isModified ? null : Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: isModified
+        color: isModified
             ? null
-            : Border.all(
-                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-              ),
+            : (appStyle.useBorderlessButtons
+                  ? appStyle.strongSurface
+                  : Theme.of(context).colorScheme.surface),
+        borderRadius: BorderRadius.circular(12),
+        border: isModified ? null : appStyle.surfaceBorder(),
         boxShadow: isModified
-            ? [
-                BoxShadow(
-                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
-                  blurRadius: 8,
-                  offset: const Offset(0, 2),
-                ),
-              ]
-            : null,
+            ? appStyle.prominentShadow
+            : (appStyle.useBorderlessButtons ? appStyle.surfaceShadow : null),
       ),
       child: Material(
         color: Colors.transparent,

--- a/lib/screens/folder/components/folder_browser_header.dart
+++ b/lib/screens/folder/components/folder_browser_header.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+
 import '../../../models/file_sort_option.dart';
+import '../../../utils/app_style.dart';
 
 class FolderBrowserHeader extends StatelessWidget {
   final String folderName;
@@ -49,9 +51,10 @@ class FolderBrowserHeader extends StatelessWidget {
             IconButton(
               icon: Container(
                 padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+                decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
                   borderRadius: BorderRadius.circular(12),
+                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+                  prominent: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
                 ),
                 child: Icon(
                   Icons.arrow_back,
@@ -124,12 +127,15 @@ class FolderBrowserHeader extends StatelessWidget {
           Expanded(
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
+              decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
-                ),
+                color: Theme.of(context).colorScheme.surface,
+                prominent: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
+                border: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons
+                    ? null
+                    : Border.all(
+                        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+                      ),
               ),
               child: TextField(
                 controller: searchController,
@@ -161,16 +167,19 @@ class FolderBrowserHeader extends StatelessWidget {
         onTap: onPressed,
         child: Container(
           padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            color: isActive 
+          decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
+            borderRadius: BorderRadius.circular(12),
+            color: isActive
                 ? colorScheme.primary.withValues(alpha: 0.1)
                 : colorScheme.surface.withValues(alpha: 0.5),
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: isActive 
-                  ? colorScheme.primary 
-                  : Theme.of(context).dividerColor.withValues(alpha: 0.5),
-            ),
+            prominent: isActive && Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
+            border: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons
+                ? null
+                : Border.all(
+                    color: isActive
+                        ? colorScheme.primary
+                        : Theme.of(context).dividerColor.withValues(alpha: 0.5),
+                  ),
           ),
           child: Icon(
             icon, 
@@ -190,12 +199,10 @@ class FolderBrowserHeader extends StatelessWidget {
         onTap: () => _showSortMenu(context),
         child: Container(
           padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.5),
+          decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-            ),
+            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.5),
+            prominent: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
           ),
           child: const Icon(Icons.sort, size: 20),
         ),

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:file_picker/file_picker.dart';
 import '../../providers/settings_provider.dart';
+import '../../utils/app_style.dart';
 import '../../utils/constants.dart';
 import '../../services/font_service.dart';
 import '../../widgets/app_background.dart';
@@ -42,6 +43,8 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
     }
   }
 
+  AppStyleTheme get _appStyle => Theme.of(context).extension<AppStyleTheme>()!;
+
   @override
   Widget build(BuildContext context) {
     return AppBackground(
@@ -66,6 +69,12 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
 
                 _buildSection('主题色', Icons.color_lens, [
                   _buildThemeColorSelector(settings),
+                ]),
+
+                const SizedBox(height: 16),
+
+                _buildSection('按钮风格', Icons.smart_button_outlined, [
+                  _buildButtonStyleSelector(settings),
                 ]),
 
                 // 浅色主题方案（仅在浅色模式下显示）
@@ -155,12 +164,9 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
   Widget _buildSection(String title, IconData icon, List<Widget> children) {
     return Container(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+      decoration: _appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.72),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -232,18 +238,7 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
       onTap: () => settings.setThemeMode(mode),
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 12),
-        decoration: BoxDecoration(
-          color: isSelected
-              ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-              : Colors.transparent,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: isSelected
-                ? Theme.of(context).colorScheme.primary
-                : Theme.of(context).dividerColor,
-            width: isSelected ? 2 : 1,
-          ),
-        ),
+        decoration: _buildOptionDecoration(isSelected: isSelected),
         child: Column(
           children: [
             Icon(
@@ -266,6 +261,123 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildButtonStyleSelector(SettingsProvider settings) {
+    return Row(
+      children: [
+        Expanded(
+          child: _buildButtonStyleOption(
+            settings,
+            AppButtonStyleMode.classic,
+            Icons.crop_square_rounded,
+            '经典描边',
+            '保留当前的实线边框按钮样式',
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: _buildButtonStyleOption(
+            settings,
+            AppButtonStyleMode.softShadow,
+            Icons.auto_awesome_rounded,
+            '简洁立体',
+            '无边框 + 阴影投影，接近 ChatGPT App 风格',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildButtonStyleOption(
+    SettingsProvider settings,
+    AppButtonStyleMode mode,
+    IconData icon,
+    String title,
+    String subtitle,
+  ) {
+    final isSelected = settings.buttonStyleMode == mode;
+    final previewPrimary = Theme.of(context).colorScheme.primary;
+    final previewSurface = _appStyle.useBorderlessButtons && mode == AppButtonStyleMode.softShadow
+        ? _appStyle.strongSurface
+        : Theme.of(context).colorScheme.surface;
+
+    return GestureDetector(
+      onTap: () => settings.setButtonStyleMode(mode),
+      child: Container(
+        padding: const EdgeInsets.all(14),
+        decoration: _buildOptionDecoration(isSelected: isSelected),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, color: isSelected ? previewPrimary : Theme.of(context).colorScheme.onSurface),
+                const Spacer(),
+                if (isSelected) Icon(Icons.check_circle, color: previewPrimary, size: 20),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: isSelected ? previewPrimary : null,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              subtitle,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 14),
+            Row(
+              children: [
+                Expanded(
+                  child: Container(
+                    height: 40,
+                    decoration: mode == AppButtonStyleMode.softShadow
+                        ? BoxDecoration(
+                            color: previewSurface,
+                            borderRadius: BorderRadius.circular(14),
+                            boxShadow: _appStyle.prominentShadow,
+                          )
+                        : BoxDecoration(
+                            color: previewPrimary,
+                            borderRadius: BorderRadius.circular(14),
+                            border: Border.all(color: previewPrimary),
+                          ),
+                    alignment: Alignment.center,
+                    child: Text(
+                      '按钮预览',
+                      style: TextStyle(
+                        color: mode == AppButtonStyleMode.softShadow ? Theme.of(context).colorScheme.onSurface : Colors.white,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  BoxDecoration _buildOptionDecoration({required bool isSelected}) {
+    final primary = Theme.of(context).colorScheme.primary;
+    return _appStyle.surfaceDecoration(
+      borderRadius: BorderRadius.circular(12),
+      color: _appStyle.optionBackground(context, selected: isSelected),
+      prominent: isSelected && _appStyle.useBorderlessButtons,
+      border: _appStyle.useBorderlessButtons
+          ? null
+          : Border.all(
+              color: isSelected ? primary : _appStyle.outlineColor,
+              width: isSelected ? 2 : 1,
+            ),
     );
   }
 
@@ -318,15 +430,18 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
             borderRadius: BorderRadius.circular(12),
             child: Container(
               padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: scheme.background,
+              decoration: _appStyle.surfaceDecoration(
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: isSelected
-                      ? Theme.of(context).colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
+                color: scheme.background,
+                prominent: isSelected && _appStyle.useBorderlessButtons,
+                border: _appStyle.useBorderlessButtons
+                    ? null
+                    : Border.all(
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.primary
+                            : Colors.transparent,
+                        width: 2,
+                      ),
               ),
               child: Row(
                 children: [
@@ -336,9 +451,12 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
                     decoration: BoxDecoration(
                       color: scheme.surface,
                       borderRadius: BorderRadius.circular(6),
-                      border: Border.all(
-                        color: scheme.textSecondary.withValues(alpha: 0.3),
-                      ),
+                      border: _appStyle.useBorderlessButtons
+                          ? null
+                          : Border.all(
+                              color: scheme.textSecondary.withValues(alpha: 0.3),
+                            ),
+                      boxShadow: _appStyle.useBorderlessButtons ? _appStyle.surfaceShadow : null,
                     ),
                   ),
                   const SizedBox(width: 12),
@@ -374,15 +492,18 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
             borderRadius: BorderRadius.circular(12),
             child: Container(
               padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: scheme.background,
+              decoration: _appStyle.surfaceDecoration(
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(
-                  color: isSelected
-                      ? Theme.of(context).colorScheme.primary
-                      : Colors.transparent,
-                  width: 2,
-                ),
+                color: scheme.background,
+                prominent: isSelected && _appStyle.useBorderlessButtons,
+                border: _appStyle.useBorderlessButtons
+                    ? null
+                    : Border.all(
+                        color: isSelected
+                            ? Theme.of(context).colorScheme.primary
+                            : Colors.transparent,
+                        width: 2,
+                      ),
               ),
               child: Row(
                 children: [

--- a/lib/utils/app_style.dart
+++ b/lib/utils/app_style.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+
+/// 应用按钮风格模式。
+enum AppButtonStyleMode {
+  classic,
+  softShadow,
+}
+
+/// 统一管理按钮与边框风格的主题扩展。
+class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
+  final AppButtonStyleMode buttonStyleMode;
+  final Color outlineColor;
+  final Color mutedSurface;
+  final Color strongSurface;
+  final List<BoxShadow> surfaceShadow;
+  final List<BoxShadow> prominentShadow;
+
+  const AppStyleTheme({
+    required this.buttonStyleMode,
+    required this.outlineColor,
+    required this.mutedSurface,
+    required this.strongSurface,
+    required this.surfaceShadow,
+    required this.prominentShadow,
+  });
+
+  bool get useBorderlessButtons => buttonStyleMode == AppButtonStyleMode.softShadow;
+
+  static AppStyleTheme resolve({
+    required Brightness brightness,
+    required ColorScheme colorScheme,
+    required Color textSecondary,
+    required AppButtonStyleMode buttonStyleMode,
+  }) {
+    final isDark = brightness == Brightness.dark;
+    final outlineColor = textSecondary.withValues(
+      alpha: buttonStyleMode == AppButtonStyleMode.softShadow ? (isDark ? 0.0 : 0.04) : (isDark ? 0.28 : 0.16),
+    );
+    final shadowColor = Colors.black.withValues(alpha: isDark ? 0.24 : 0.10);
+    final prominentColor = colorScheme.primary.withValues(alpha: isDark ? 0.24 : 0.18);
+
+    return AppStyleTheme(
+      buttonStyleMode: buttonStyleMode,
+      outlineColor: outlineColor,
+      mutedSurface: Color.alphaBlend(
+        colorScheme.primary.withValues(alpha: isDark ? 0.08 : 0.04),
+        colorScheme.surface,
+      ),
+      strongSurface: Color.alphaBlend(
+        Colors.white.withValues(alpha: isDark ? 0.03 : 0.7),
+        colorScheme.surface,
+      ),
+      surfaceShadow: buttonStyleMode == AppButtonStyleMode.softShadow
+          ? [
+              BoxShadow(
+                color: shadowColor,
+                blurRadius: isDark ? 20 : 24,
+                offset: const Offset(0, 10),
+                spreadRadius: isDark ? -12 : -14,
+              ),
+              BoxShadow(
+                color: Colors.white.withValues(alpha: isDark ? 0.02 : 0.7),
+                blurRadius: 12,
+                offset: const Offset(0, -1),
+                spreadRadius: -10,
+              ),
+            ]
+          : const [],
+      prominentShadow: [
+        BoxShadow(
+          color: prominentColor,
+          blurRadius: buttonStyleMode == AppButtonStyleMode.softShadow ? 20 : 12,
+          offset: const Offset(0, 8),
+          spreadRadius: buttonStyleMode == AppButtonStyleMode.softShadow ? -10 : -8,
+        ),
+      ],
+    );
+  }
+
+  Border? surfaceBorder({Color? color}) {
+    if (useBorderlessButtons) return null;
+    return Border.all(color: color ?? outlineColor);
+  }
+
+  Color optionBackground(BuildContext context, {required bool selected}) {
+    if (selected) {
+      return Theme.of(context).colorScheme.primary.withValues(alpha: useBorderlessButtons ? 0.12 : 0.10);
+    }
+    return useBorderlessButtons ? strongSurface : Colors.transparent;
+  }
+
+  BoxDecoration surfaceDecoration({
+    required BorderRadius borderRadius,
+    Color? color,
+    bool prominent = false,
+    Border? border,
+  }) {
+    return BoxDecoration(
+      color: color ?? strongSurface,
+      borderRadius: borderRadius,
+      border: border ?? surfaceBorder(),
+      boxShadow: prominent ? prominentShadow : surfaceShadow,
+    );
+  }
+
+  @override
+  AppStyleTheme copyWith({
+    AppButtonStyleMode? buttonStyleMode,
+    Color? outlineColor,
+    Color? mutedSurface,
+    Color? strongSurface,
+    List<BoxShadow>? surfaceShadow,
+    List<BoxShadow>? prominentShadow,
+  }) {
+    return AppStyleTheme(
+      buttonStyleMode: buttonStyleMode ?? this.buttonStyleMode,
+      outlineColor: outlineColor ?? this.outlineColor,
+      mutedSurface: mutedSurface ?? this.mutedSurface,
+      strongSurface: strongSurface ?? this.strongSurface,
+      surfaceShadow: surfaceShadow ?? this.surfaceShadow,
+      prominentShadow: prominentShadow ?? this.prominentShadow,
+    );
+  }
+
+  @override
+  AppStyleTheme lerp(ThemeExtension<AppStyleTheme>? other, double t) {
+    if (other is! AppStyleTheme) return this;
+    return AppStyleTheme(
+      buttonStyleMode: t < 0.5 ? buttonStyleMode : other.buttonStyleMode,
+      outlineColor: Color.lerp(outlineColor, other.outlineColor, t) ?? outlineColor,
+      mutedSurface: Color.lerp(mutedSurface, other.mutedSurface, t) ?? mutedSurface,
+      strongSurface: Color.lerp(strongSurface, other.strongSurface, t) ?? strongSurface,
+      surfaceShadow: t < 0.5 ? surfaceShadow : other.surfaceShadow,
+      prominentShadow: t < 0.5 ? prominentShadow : other.prominentShadow,
+    );
+  }
+}

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:mdreader/providers/settings_provider.dart';
+import 'package:mdreader/utils/app_style.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -31,6 +32,7 @@ void main() {
       expect(provider.autoSaveInterval, 30);
       expect(provider.webdavUrl, isEmpty);
       expect(provider.syncFolderName, 'Ushio-MD');
+      expect(provider.buttonStyleMode, AppButtonStyleMode.classic);
     });
 
     test('setThemeMode 应更新内存和持久化存储', () async {
@@ -47,6 +49,15 @@ void main() {
       
       final prefs = await SharedPreferences.getInstance();
       expect(prefs.getDouble('font_size'), 20.0);
+    });
+
+    test('setButtonStyleMode 应更新内存和持久化存储', () async {
+      await provider.setButtonStyleMode(AppButtonStyleMode.softShadow);
+      expect(provider.buttonStyleMode, AppButtonStyleMode.softShadow);
+      expect(provider.useBorderlessButtons, isTrue);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('button_style_mode'), AppButtonStyleMode.softShadow.name);
     });
 
     test('WebDAV 密码应存储在 SecureStorage 中', () async {


### PR DESCRIPTION
### Motivation
- Provide a user-facing appearance option to switch between the existing outlined button style and a concise borderless + soft-shadow style (ChatGPT-like) so the whole app can present a consistent, modern look.
- Ensure that when the style is switched, all solid/outlined borders across buttons, cards, inputs and group containers toggle together to keep the app visuals unified.

### Description
- Add a theme extension `AppStyleTheme` and enum `AppButtonStyleMode` in `lib/utils/app_style.dart` that centralizes outline, surface and shadow values and exposes helpers like `surfaceDecoration` and `surfaceBorder` to drive borderless vs outlined rendering.
- Add a persisted button-style setting to `SettingsProvider` (`_buttonStyleMode`, getter `buttonStyleMode`, `useBorderlessButtons`, loading from `SharedPreferences` and `setButtonStyleMode`), located in `lib/providers/settings_provider.dart`.
- Integrate the new style extension into app themes in `lib/main.dart` by resolving `AppStyleTheme` per light/dark theme and wiring button/input/card/icon styles to switch based on the selected mode via a shared `_buildTheme` helper.
- Expose a new UI in the appearance settings at `lib/screens/settings/appearance_settings_screen.dart` to preview and toggle between `经典描边` and `简洁立体` styles, and update section containers and option cards to use `AppStyleTheme.surfaceDecoration` so borders and shadows change consistently.
- Update key header controls so they follow the unified style: `lib/screens/editor/components/editor_header.dart` and `lib/screens/folder/components/folder_browser_header.dart` now read the `AppStyleTheme` to render icon/save/search containers and inputs consistently.
- Add a unit test case to `test/providers/settings_provider_test.dart` covering default value and persistence for the new `buttonStyleMode` setting.

### Testing
- `git diff --check` completed with no issues (code consistency check succeeded).
- `dart format lib/...` was attempted but failed because the Dart SDK is not available in this environment (`/bin/bash: line 1: dart: command not found`).
- `flutter test test/providers/settings_provider_test.dart` could not be run in this environment because the Flutter SDK is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbb5c4b7cc83218b53fa27a27f423d)