### PR TITLE
fix: unify “简洁立体” card styling across home/file/history/settings surfaces

### DIFF
--- a/lib/screens/folder/components/file_tile.dart
+++ b/lib/screens/folder/components/file_tile.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import '../../../providers/file_provider.dart';
 import '../../../utils/file_actions.dart';
 import '../../../utils/editor_navigation_helper.dart';
+import '../../../utils/app_style.dart';
 import '../../folder_browser_screen.dart';
 
 class FileTile extends StatelessWidget {
@@ -24,6 +25,7 @@ class FileTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     final isFile = entity is File;
     final name = entity.path.split(Platform.pathSeparator).last;
     final isImage = isFile && _isImage(name);
@@ -47,14 +49,18 @@ class FileTile extends StatelessWidget {
 
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: isPinned 
-              ? (isFile ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.3) : Colors.amber.withValues(alpha: 0.3))
-              : Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: isPinned
+                    ? (isFile
+                        ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.3)
+                        : Colors.amber.withValues(alpha: 0.3))
+                    : Theme.of(context).dividerColor.withValues(alpha: 0.5),
+              ),
       ),
       child: Material(
         color: Colors.transparent,

--- a/lib/screens/main/components/quick_actions.dart
+++ b/lib/screens/main/components/quick_actions.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../providers/file_provider.dart';
 import '../../../utils/file_actions.dart';
 import '../../../utils/file_import_helper.dart';
+import '../../../utils/app_style.dart';
 
 import '../../../screens/folder_browser_screen.dart';
 
@@ -12,6 +13,7 @@ class QuickActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     bool hasPinnedItems = fileProvider.pinnedFiles.isNotEmpty || fileProvider.pinnedFolders.isNotEmpty;
     
     if (hasPinnedItems) {
@@ -21,6 +23,8 @@ class QuickActions extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: appStyle.surfaceShadow,
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
@@ -29,10 +33,11 @@ class QuickActions extends StatelessWidget {
             Theme.of(context).colorScheme.secondary.withValues(alpha: 0.1),
           ],
         ),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
-        ),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+              ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -130,9 +135,12 @@ class QuickActions extends StatelessWidget {
   }
 
   Widget _buildCompactQuickActions(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: appStyle.surfaceShadow,
         gradient: LinearGradient(
           begin: Alignment.centerLeft, // Horizontal gradient for compact row
           end: Alignment.centerRight,
@@ -141,10 +149,11 @@ class QuickActions extends StatelessWidget {
             Theme.of(context).colorScheme.secondary.withValues(alpha: 0.1),
           ],
         ),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
-        ),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+              ),
       ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -238,6 +247,7 @@ class QuickActions extends StatelessWidget {
     required Color color,
     required VoidCallback onTap,
   }) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -245,12 +255,14 @@ class QuickActions extends StatelessWidget {
         onTap: onTap,
         child: Container(
           padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+          decoration: appStyle.surfaceDecoration(
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: color.withValues(alpha: 0.3),
-            ),
+            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+            border: appStyle.useBorderlessButtons
+                ? null
+                : Border.all(
+                    color: color.withValues(alpha: 0.3),
+                  ),
           ),
           child: Column(
             children: [

--- a/lib/screens/main/tabs/history_tab.dart
+++ b/lib/screens/main/tabs/history_tab.dart
@@ -10,6 +10,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import '../../../providers/file_provider.dart';
 import '../../../widgets/empty_state.dart';
+import '../../../utils/app_style.dart';
 
 import '../../../utils/file_actions.dart';
 import '../../folder/components/file_tile.dart';
@@ -109,13 +110,16 @@ class _HistoryTabState extends State<HistoryTab> {
   }
 
   Widget _buildToggleButton() {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+              ),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,

--- a/lib/screens/main/tabs/settings_tab.dart
+++ b/lib/screens/main/tabs/settings_tab.dart
@@ -10,6 +10,7 @@ import 'package:provider/provider.dart';
 import '../../../providers/settings_provider.dart';
 import '../../../providers/plugin_provider.dart';
 import '../../../utils/constants.dart';
+import '../../../utils/app_style.dart';
 import '../../settings/appearance_settings_screen.dart';
 import '../../settings/editor_settings_screen.dart';
 import '../../settings/cloud_sync_screen.dart';
@@ -161,14 +162,17 @@ class SettingsTab extends StatelessWidget {
     required String subtitle,
     required VoidCallback onTap,
   }) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+              ),
       ),
       child: Material(
         color: Colors.transparent,

--- a/lib/screens/settings/about_screen.dart
+++ b/lib/screens/settings/about_screen.dart
@@ -12,6 +12,7 @@ import '../../utils/constants.dart';
 import '../../services/update_service.dart';
 import '../../widgets/app_background.dart';
 import '../../providers/settings_provider.dart';
+import '../../utils/app_style.dart';
 
 class AboutScreen extends StatefulWidget {
   const AboutScreen({super.key});
@@ -59,9 +60,11 @@ class _AboutScreenState extends State<AboutScreen> {
   }
 
   Widget _buildAppInfo() {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
+        boxShadow: appStyle.surfaceShadow,
         gradient: LinearGradient(
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
@@ -71,9 +74,11 @@ class _AboutScreenState extends State<AboutScreen> {
           ],
         ),
         borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
-        ),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+              ),
       ),
       child: Column(
         children: [
@@ -130,14 +135,17 @@ class _AboutScreenState extends State<AboutScreen> {
   }
 
   Widget _buildSection(String title, IconData icon, List<Widget> children) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+              ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -929,18 +929,21 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
                   margin: EdgeInsets.only(right: idx == 0 ? 8 : 0),
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
+                    boxShadow: _appStyle.useBorderlessButtons ? _appStyle.surfaceShadow : null,
                     color: isSelected
                         ? Theme.of(
                             context,
                           ).colorScheme.primary.withValues(alpha: 0.1)
-                        : Colors.transparent,
+                        : (_appStyle.useBorderlessButtons ? _appStyle.strongSurface : Colors.transparent),
                     borderRadius: BorderRadius.circular(12),
-                    border: Border.all(
-                      color: isSelected
-                          ? Theme.of(context).colorScheme.primary
-                          : Theme.of(context).dividerColor,
-                      width: isSelected ? 2 : 1,
-                    ),
+                    border: _appStyle.useBorderlessButtons
+                        ? null
+                        : Border.all(
+                            color: isSelected
+                                ? Theme.of(context).colorScheme.primary
+                                : Theme.of(context).dividerColor,
+                            width: isSelected ? 2 : 1,
+                          ),
                   ),
                   child: Column(
                     children: [
@@ -1116,16 +1119,19 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 8),
         decoration: BoxDecoration(
+          boxShadow: _appStyle.useBorderlessButtons ? _appStyle.surfaceShadow : null,
           color: isSelected
               ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-              : Colors.transparent,
+              : (_appStyle.useBorderlessButtons ? _appStyle.strongSurface : Colors.transparent),
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: isSelected
-                ? Theme.of(context).colorScheme.primary
-                : Theme.of(context).dividerColor,
-            width: isSelected ? 2 : 1,
-          ),
+          border: _appStyle.useBorderlessButtons
+              ? null
+              : Border.all(
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).dividerColor,
+                  width: isSelected ? 2 : 1,
+                ),
         ),
         child: Column(
           children: [
@@ -1176,16 +1182,19 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
+          boxShadow: _appStyle.useBorderlessButtons ? _appStyle.surfaceShadow : null,
           color: isSelected
               ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.1)
-              : Colors.transparent,
+              : (_appStyle.useBorderlessButtons ? _appStyle.strongSurface : Colors.transparent),
           borderRadius: BorderRadius.circular(12),
-          border: Border.all(
-            color: isSelected
-                ? Theme.of(context).colorScheme.primary
-                : Theme.of(context).dividerColor,
-            width: isSelected ? 2 : 1,
-          ),
+          border: _appStyle.useBorderlessButtons
+              ? null
+              : Border.all(
+                  color: isSelected
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).dividerColor,
+                  width: isSelected ? 2 : 1,
+                ),
         ),
         child: Row(
           children: [

--- a/lib/screens/settings/cloud_sync_screen.dart
+++ b/lib/screens/settings/cloud_sync_screen.dart
@@ -18,6 +18,7 @@ import '../../services/sync_service_interface.dart';
 import '../../services/my_files_service.dart';
 import '../../services/cloud_sync_service.dart';
 import '../../widgets/app_background.dart';
+import '../../utils/app_style.dart';
 
 class CloudSyncScreen extends StatefulWidget {
   const CloudSyncScreen({super.key});
@@ -204,17 +205,21 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
 
   Widget _buildInfoCard() {
     final settings = context.watch<SettingsProvider>();
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     final fullPath = settings.getFullSyncPath();
     final syncTypeName = _selectedSyncType == 'webdav' ? 'WebDAV' : 'FTP';
 
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
+        boxShadow: appStyle.surfaceShadow,
         color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
-        ),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+              ),
       ),
       child: Row(
         children: [
@@ -554,6 +559,7 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
   }
 
   Widget _buildSyncControlsSection(SettingsProvider settings) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -566,12 +572,14 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
         const SizedBox(height: 16),
         Container(
           padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
+          decoration: appStyle.surfaceDecoration(
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-            ),
+            color: Theme.of(context).colorScheme.surface,
+            border: appStyle.useBorderlessButtons
+                ? null
+                : Border.all(
+                    color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+                  ),
           ),
           child: Column(
             children: [
@@ -749,6 +757,7 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
   }
 
   Widget _buildStatusSection(SettingsProvider settings) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     final syncTypeName = settings.syncType == 'webdav' ? 'WebDAV' : 'FTP';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -762,12 +771,14 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
         const SizedBox(height: 16),
         Container(
           padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
+          decoration: appStyle.surfaceDecoration(
             borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-            ),
+            color: Theme.of(context).colorScheme.surface,
+            border: appStyle.useBorderlessButtons
+                ? null
+                : Border.all(
+                    color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+                  ),
           ),
           child: Column(
             children: [
@@ -1247,4 +1258,3 @@ class _CloudSyncScreenState extends State<CloudSyncScreen> {
     return '${time.month}/${time.day} ${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
   }
 }
-

--- a/lib/screens/settings/editor_settings_screen.dart
+++ b/lib/screens/settings/editor_settings_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../widgets/app_background.dart';
+import '../../utils/app_style.dart';
 
 class EditorSettingsScreen extends StatelessWidget {
   const EditorSettingsScreen({super.key});
@@ -50,14 +51,17 @@ class EditorSettingsScreen extends StatelessWidget {
   }
 
   Widget _buildSection(BuildContext context, String title, IconData icon, List<Widget> children) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+              ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screens/settings/storage_settings_screen.dart
+++ b/lib/screens/settings/storage_settings_screen.dart
@@ -11,6 +11,7 @@ import '../../providers/file_provider.dart';
 import '../../providers/settings_provider.dart';
 import '../../services/my_files_service.dart';
 import '../../widgets/app_background.dart';
+import '../../utils/app_style.dart';
 
 class StorageSettingsScreen extends StatefulWidget {
   const StorageSettingsScreen({super.key});
@@ -107,14 +108,17 @@ class _StorageSettingsScreenState extends State<StorageSettingsScreen> {
   }
 
   Widget _buildSection(String title, IconData icon, List<Widget> children) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(
+                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+              ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
### Motivation
- The “简洁立体” (soft-shadow / borderless) button style was not applied consistently across many UI surfaces (quick actions, file/folder cards, history toggle, settings cards, cloud sync cards, appearance icon options), causing visual inconsistency when that mode is selected.

### Description
- Replace hardcoded `BoxDecoration` borders/backgrounds with `AppStyleTheme` helpers so surfaces use `surfaceDecoration`/`surfaceShadow` and obey `useBorderlessButtons` (soft-shadow) logic; key files updated: `lib/screens/main/components/quick_actions.dart`, `lib/screens/folder/components/file_tile.dart`, `lib/screens/main/tabs/history_tab.dart`, `lib/screens/main/tabs/settings_tab.dart`, `lib/screens/settings/cloud_sync_screen.dart`, `lib/screens/settings/editor_settings_screen.dart`, `lib/screens/settings/storage_settings_screen.dart`, `lib/screens/settings/about_screen.dart`, `lib/screens/settings/appearance_settings_screen.dart`.
- For cards and option tiles we conditionally remove `Border.all(...)` when `appStyle.useBorderlessButtons` is true and add `appStyle.surfaceShadow` / `appStyle.strongSurface` to mimic the intended soft-shadow look; appearance icon options also switch background/border/shadow based on the mode.
- No business logic changes were introduced; this is strictly a visual/theme refactor to centralize decoration via `AppStyleTheme`.

### Testing
- Ran `git status --short` to verify working tree and changes were staged, which succeeded. 
- Attempted to run `dart format` on modified files but it failed due to the environment lacking `dart` (command reported `dart: command not found`).
- Attempted to run `flutter --version` but it failed due to the environment lacking `flutter` (command reported `flutter: command not found`).
- Created a commit containing the visual/style changes which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd89709908329937d946375f9ef57)