### PR TITLE
Refine webview editor header layout

### DIFF
--- a/lib/screens/editor/components/editor_header.dart
+++ b/lib/screens/editor/components/editor_header.dart
@@ -20,6 +20,9 @@ class EditorHeader extends StatelessWidget {
     this.onMore,
   });
 
+  String get _displayFileName =>
+      fileName.replaceAll('.markdown', '').replaceAll('.md', '');
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -48,37 +51,10 @@ class EditorHeader extends StatelessWidget {
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Row(
-                  children: [
-                    Flexible(
-                      child: Text(
-                        fileName.replaceAll('.md', '').replaceAll('.markdown', ''),
-                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                            ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    if (isModified)
-                      Container(
-                        margin: const EdgeInsets.only(left: 8),
-                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-                        decoration: BoxDecoration(
-                          color: Colors.orange.withValues(alpha: 0.2),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: const Text(
-                          '未保存',
-                          style: TextStyle(
-                            color: Colors.orange,
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
+                _AdaptiveFileName(fileName: _displayFileName),
+                const SizedBox(height: 4),
                 Text(
                   wordCount,
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
@@ -88,6 +64,7 @@ class EditorHeader extends StatelessWidget {
               ],
             ),
           ),
+          const SizedBox(width: 8),
           _buildSaveButton(context),
           if (onMore != null) ...[
             const SizedBox(width: 8),
@@ -116,71 +93,125 @@ class EditorHeader extends StatelessWidget {
   }
 
   Widget _buildSaveButton(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        gradient: isModified
-            ? LinearGradient(
-                colors: [
-                  Theme.of(context).colorScheme.primary,
-                  Theme.of(context).colorScheme.secondary,
-                ],
-              )
-            : null,
-        color: isModified ? null : Theme.of(context).colorScheme.surface,
-        borderRadius: BorderRadius.circular(12),
-        border: isModified
-            ? null
-            : Border.all(
-                color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-              ),
-        boxShadow: isModified
-            ? [
-                BoxShadow(
-                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
-                  blurRadius: 8,
-                  offset: const Offset(0, 2),
-                ),
-              ]
-            : null,
-      ),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
+    final colorScheme = Theme.of(context).colorScheme;
+    final iconColor = isSaving
+        ? colorScheme.primary
+        : isModified
+            ? Colors.orange
+            : colorScheme.outline;
+
+    return Tooltip(
+      message: isSaving ? '保存中' : '保存',
+      child: Container(
+        decoration: BoxDecoration(
+          color: colorScheme.surface.withValues(alpha: 0.8),
           borderRadius: BorderRadius.circular(12),
-          onTap: isSaving ? null : onSave,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (isSaving)
-                  SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: isModified ? Colors.white : null,
-                    ),
-                  )
-                else
-                  Icon(
-                    Icons.save,
-                    size: 18,
-                    color: isModified ? Colors.white : null,
-                  ),
-                const SizedBox(width: 8),
-                Text(
-                  '保存',
-                  style: TextStyle(
-                    color: isModified ? Colors.white : null,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ],
+          border: Border.all(
+            color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
+          ),
+        ),
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            borderRadius: BorderRadius.circular(12),
+            onTap: isSaving ? null : onSave,
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 180),
+                child: isSaving
+                    ? SizedBox(
+                        key: const ValueKey('saving'),
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: iconColor,
+                        ),
+                      )
+                    : Icon(
+                        Icons.save,
+                        key: ValueKey('save-$isModified'),
+                        size: 20,
+                        color: iconColor,
+                      ),
+              ),
             ),
           ),
         ),
       ),
     );
+  }
+}
+
+class _AdaptiveFileName extends StatelessWidget {
+  final String fileName;
+
+  const _AdaptiveFileName({required this.fileName});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final baseStyle = theme.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.bold,
+          height: 1.1,
+        ) ??
+        const TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+          height: 1.1,
+        );
+
+    final title = fileName.trim().isEmpty ? '未命名' : fileName.trim();
+    final glyphs = title.runes.length;
+    final lineCount = glyphs <= 10 ? 1 : 2;
+    final displayTitle = _formatTitle(title);
+    final sizeScale = glyphs <= 10
+        ? 1.0
+        : glyphs <= 14
+            ? 0.94
+            : glyphs <= 18
+                ? 0.88
+                : 0.82;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final lineHeight = (baseStyle.fontSize ?? 16) * (baseStyle.height ?? 1.1);
+        final maxHeight = lineHeight * lineCount + 2;
+
+        return ConstrainedBox(
+          constraints: BoxConstraints(
+            minHeight: lineHeight,
+            maxHeight: maxHeight,
+            maxWidth: constraints.maxWidth,
+          ),
+          child: Text(
+            displayTitle,
+            maxLines: 2,
+            softWrap: true,
+            overflow: TextOverflow.ellipsis,
+            style: baseStyle.copyWith(
+              fontSize: (baseStyle.fontSize ?? 16) * sizeScale,
+            ),
+            strutStyle: StrutStyle(
+              fontSize: (baseStyle.fontSize ?? 16) * sizeScale,
+              height: baseStyle.height,
+              forceStrutHeight: true,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _formatTitle(String title) {
+    final chars = title.runes.toList();
+    if (chars.length <= 10) {
+      return title;
+    }
+
+    final firstLine = String.fromCharCodes(chars.take(10));
+    final secondLine = String.fromCharCodes(chars.skip(10).take(10));
+    return '$firstLine\n$secondLine';
   }
 }

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -1238,8 +1238,12 @@ class _EditorScreenState extends State<EditorScreen>
   String _getWordCount() {
     final text = _textController.text;
     final chars = text.length;
+    final glyphs = text.runes.where((char) {
+      final value = String.fromCharCode(char);
+      return value.trim().isNotEmpty;
+    }).length;
     final words = text.split(_wordSplitRegex).where((w) => w.isNotEmpty).length;
-    return '$chars 字符 · $words 词';
+    return '$chars 字符 · $glyphs 文字 · $words 单词';
   }
 
   Widget _buildContent() {


### PR DESCRIPTION
### Motivation
- 节省顶栏空间并提升可读性，通过把保存操作缩成图标、移除“未保存”文本标签，为文件标题腾出更多空间并用图标颜色/状态反馈保存进度。 
- 增强顶部统计信息的可用性，需要同时显示字符、可见文字（去除空白）和单词三个维度。 
- 让文件名在顶栏自适应长度与字号，以在有限空间内更好地展示短/长文件名。 

### Description
- 将右侧保存控件从带文字的按钮改为图标/指示器，仅用图标颜色与加载指示器反馈保存状态，并保留 `Tooltip`（文件：`lib/screens/editor/components/editor_header.dart`）。
- 移除顶栏内的“未保存”文字标签，改为通过保存图标颜色表示修改状态（文件：`lib/screens/editor/components/editor_header.dart`）。
- 将左侧统计由原来的 `"$chars 字符 · $words 词"` 更新为 `"$chars 字符 · $glyphs 文字 · $words 单词"`，其中 `文字` 为去除空白后的字符计数（文件：`lib/screens/editor_screen.dart`）。
- 新增 `_AdaptiveFileName` 组件实现标题自适应：短标题保持默认字号，超过 10 字符时最多按两行展示并按字数缩小字号，超出两行以省略号收尾（文件：`lib/screens/editor/components/editor_header.dart`）。
- 已将修改提交（提交信息：`Refine webview editor header layout`）。

### Testing
- 运行 `git diff --check` 检查通过。 
- 尝试运行 `dart format` / `flutter format` / `flutter test test/screens/editor_screen_test.dart` 时环境中未安装 `dart`/`flutter`，因此格式化与单元测试未能在此容器中执行。 
- 已在代码层面执行本地文本替换与 sanity 检查并提交改动。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbeb68b4d4832183da6f05bd98172f)