### PR TITLE
Fix editor init modal hang, correct PDF markdown stripping, and add customizable home title

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -125,6 +125,9 @@ class SettingsProvider extends ChangeNotifier {
   /// 主页自定义图标路径（仅当 homeIconMode == 'custom' 时有效）
   String? _homeIconCustomPath;
 
+  /// 主页左上角标题文字
+  String _homeTitleText = '汐';
+
   // ==================== 语言设置 ====================
 
   /// 当前语言环境（默认中文）
@@ -206,6 +209,7 @@ class SettingsProvider extends ChangeNotifier {
   int get appIconIndex => _appIconIndex;
   String get homeIconMode => _homeIconMode;
   String? get homeIconCustomPath => _homeIconCustomPath;
+  String get homeTitleText => _homeTitleText;
 
   // 粒子效果 Getters
   bool get particleEnabled => _particleEnabled;
@@ -343,6 +347,7 @@ class SettingsProvider extends ChangeNotifier {
     _appIconIndex = prefs.getInt('app_icon_index') ?? 0;
     _homeIconMode = prefs.getString('home_icon_mode') ?? 'default';
     _homeIconCustomPath = prefs.getString('home_icon_custom_path');
+    _homeTitleText = prefs.getString('home_title_text') ?? '汐';
 
     // 夜间主题和字体设置
     _darkThemeIndex = prefs.getInt('dark_theme_index') ?? 0;
@@ -668,6 +673,15 @@ class SettingsProvider extends ChangeNotifier {
     } else {
       await prefs.remove('home_icon_custom_path');
     }
+    notifyListeners();
+  }
+
+  /// 设置主页标题文字
+  Future<void> setHomeTitleText(String text) async {
+    final normalized = text.trim().isEmpty ? '汐' : text.trim();
+    _homeTitleText = normalized;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('home_title_text', normalized);
     notifyListeners();
   }
 

--- a/lib/screens/main/tabs/home_tab.dart
+++ b/lib/screens/main/tabs/home_tab.dart
@@ -5,7 +5,6 @@ import '../../../../providers/file_provider.dart';
 import '../../../../providers/plugin_provider.dart';
 import '../../../../providers/settings_provider.dart';
 import '../../../../plugins/extensions/widget_extension.dart';
-import '../../../../utils/constants.dart';
 import '../../../../utils/file_actions.dart';
 
 import '../components/quick_actions.dart';
@@ -129,7 +128,7 @@ class _HomeTabState extends State<HomeTab> {
                 const SizedBox(width: 12),
               ],
               Text(
-                AppConstants.appName,
+                settings.homeTitleText,
                 style: Theme.of(
                   context,
                 ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -26,11 +26,19 @@ class AppearanceSettingsScreen extends StatefulWidget {
 class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
   List<CustomFontInfo> _customFonts = [];
   bool _loadingFonts = true;
+  late final TextEditingController _homeTitleController;
 
   @override
   void initState() {
     super.initState();
+    _homeTitleController = TextEditingController();
     _loadCustomFonts();
+  }
+
+  @override
+  void dispose() {
+    _homeTitleController.dispose();
+    super.dispose();
   }
 
   Future<void> _loadCustomFonts() async {
@@ -58,6 +66,15 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
         ),
         body: Consumer<SettingsProvider>(
           builder: (context, settings, child) {
+            final homeTitleText = settings.homeTitleText;
+            if (_homeTitleController.text != homeTitleText) {
+              _homeTitleController.value = TextEditingValue(
+                text: homeTitleText,
+                selection: TextSelection.collapsed(
+                  offset: homeTitleText.length,
+                ),
+              );
+            }
             return ListView(
               padding: const EdgeInsets.all(20),
               children: [
@@ -121,6 +138,12 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
 
                 _buildSection('主页图标', Icons.account_circle_outlined, [
                   _buildHomeIconSelector(settings),
+                ]),
+
+                const SizedBox(height: 16),
+
+                _buildSection('主页标题', Icons.title_rounded, [
+                  _buildHomeTitleTextField(settings),
                 ]),
 
                 const SizedBox(height: 16),
@@ -1280,5 +1303,53 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
         await settings.setHomeIconMode('custom');
       }
     }
+  }
+
+  Widget _buildHomeTitleTextField(SettingsProvider settings) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '自定义首页左上角文字，留空时会恢复为默认“汐”。',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.outline,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _homeTitleController,
+                maxLength: 12,
+                decoration: const InputDecoration(
+                  labelText: '首页标题',
+                  hintText: '汐',
+                  counterText: '',
+                ),
+                onSubmitted: settings.setHomeTitleText,
+              ),
+            ),
+            const SizedBox(width: 8),
+            FilledButton(
+              onPressed: () => settings.setHomeTitleText(
+                _homeTitleController.text,
+              ),
+              child: const Text('保存'),
+            ),
+          ],
+        ),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(
+            onPressed: () {
+              _homeTitleController.text = '汐';
+              settings.setHomeTitleText('汐');
+            },
+            child: const Text('恢复默认'),
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -18,7 +18,7 @@ import 'package:share_plus/share_plus.dart';
 
 /// 导出服务类
 class ExportService {
-  static final _headingRegex = RegExp(r'^(#{1,6})\s+(.+)$');
+  static final _headingRegex = RegExp(r'^(#{1,6})\s+(.+?)(?:\s+#+\s*)?$');
   static final _orderedListRegex = RegExp(r'^\s*(\d+)\.\s+(.+)$');
   static final _unorderedListRegex = RegExp(r'^\s*[-*+]\s+(.+)$');
   static final _blockquoteRegex = RegExp(r'^\s*>\s?(.*)$');
@@ -203,7 +203,7 @@ class ExportService {
       final headingMatch = _headingRegex.firstMatch(trimmed);
       if (headingMatch != null) {
         final level = headingMatch.group(1)!.length;
-        final text = headingMatch.group(2)!.trim();
+        final text = _stripInlineMarkdown(headingMatch.group(2)!.trim());
         double size;
         if (level == 1) {
           size = 22.0;
@@ -381,14 +381,35 @@ class ExportService {
 
   static String _stripInlineMarkdown(String text) {
     return text
-        .replaceAll(RegExp(r'`([^`]+)`'), r'$1')
-        .replaceAll(RegExp(r'\*\*([^*]+)\*\*'), r'$1')
-        .replaceAll(RegExp(r'__([^_]+)__'), r'$1')
-        .replaceAll(RegExp(r'\*([^*]+)\*'), r'$1')
-        .replaceAll(RegExp(r'_([^_]+)_'), r'$1')
-        .replaceAll(RegExp(r'~~([^~]+)~~'), r'$1')
-        .replaceAll(RegExp(r'!\[[^\]]*\]\(([^\)]+)\)'), r'[图片: $1]')
-        .replaceAll(RegExp(r'\[([^\]]+)\]\(([^\)]+)\)'), r'$1 ($2)')
+        .replaceAllMapped(RegExp(r'`([^`]+)`'), (match) => match.group(1) ?? '')
+        .replaceAllMapped(
+          RegExp(r'\*\*([^*]+)\*\*'),
+          (match) => match.group(1) ?? '',
+        )
+        .replaceAllMapped(
+          RegExp(r'__([^_]+)__'),
+          (match) => match.group(1) ?? '',
+        )
+        .replaceAllMapped(
+          RegExp(r'\*([^*]+)\*'),
+          (match) => match.group(1) ?? '',
+        )
+        .replaceAllMapped(
+          RegExp(r'_([^_]+)_'),
+          (match) => match.group(1) ?? '',
+        )
+        .replaceAllMapped(
+          RegExp(r'~~([^~]+)~~'),
+          (match) => match.group(1) ?? '',
+        )
+        .replaceAllMapped(
+          RegExp(r'!\[[^\]]*\]\(([^\)]+)\)'),
+          (match) => '[图片: ${match.group(1) ?? ''}]',
+        )
+        .replaceAllMapped(
+          RegExp(r'\[([^\]]+)\]\(([^\)]+)\)'),
+          (match) => '${match.group(1) ?? ''} (${match.group(2) ?? ''})',
+        )
         .trim();
   }
   

--- a/lib/utils/editor_navigation_helper.dart
+++ b/lib/utils/editor_navigation_helper.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -11,16 +10,22 @@ import '../widgets/webview_markdown_preview.dart';
 
 /// 统一处理进入编辑器前的预加载、初始化提示和缓存命中逻辑。
 class EditorNavigationHelper {
+  static bool _isOpeningDocument = false;
+
   static Future<void> openEditor(
     BuildContext context,
     String filePath, {
     VoidCallback? onFileOpened,
     String? initialContent,
   }) async {
+    if (_isOpeningDocument) return;
+    _isOpeningDocument = true;
+
     final fileProvider = context.read<FileProvider>();
     final fileService = fileProvider.fileService;
-    final isCached = initialContent != null || fileService.isFileCached(filePath);
-    final fileName = filePath.split(Platform.pathSeparator).last;
+    final isCached =
+        initialContent != null || fileService.isFileCached(filePath);
+    BuildContext? dialogContext;
 
     onFileOpened?.call();
 
@@ -30,12 +35,13 @@ class EditorNavigationHelper {
       showDialog<void>(
         context: context,
         barrierDismissible: false,
-        builder: (dialogContext) => ThemedProgressDialog(
-          title: '正在初始化文档',
-          label: fileName,
-          message: '正在预加载正文、建立缓存并预热预览引擎，稍后将直接进入可阅读状态。',
-          icon: Icons.menu_book_rounded,
-        ),
+        builder: (currentDialogContext) {
+          dialogContext = currentDialogContext;
+          return const ThemedProgressDialog(
+            title: '正在初始化文档',
+            icon: Icons.menu_book_rounded,
+          );
+        },
       );
       // 让对话框先绘制一帧，再进行较重的初始化。
       await Future<void>.delayed(const Duration(milliseconds: 16));
@@ -43,17 +49,17 @@ class EditorNavigationHelper {
 
     try {
       final preloadTasks = <Future<dynamic>>[
-        warmUpMarkdownPreviewAssets(),
+        warmUpMarkdownPreviewAssets().timeout(const Duration(seconds: 8)),
         initialContent != null
             ? Future<String>.value(initialContent)
-            : fileService.preloadFile(filePath),
+            : fileService.preloadFile(filePath).timeout(
+                const Duration(seconds: 8),
+              ),
       ];
       final results = await Future.wait(preloadTasks);
       final content = results[1] as String;
 
-      if (dialogShown && context.mounted) {
-        Navigator.of(context, rootNavigator: true).pop();
-      }
+      _dismissDialog(dialogShown, dialogContext, context);
       if (!context.mounted) return;
 
       await Navigator.push(
@@ -66,9 +72,7 @@ class EditorNavigationHelper {
         ),
       );
     } catch (e) {
-      if (dialogShown && context.mounted) {
-        Navigator.of(context, rootNavigator: true).pop();
-      }
+      _dismissDialog(dialogShown, dialogContext, context);
       if (!context.mounted) return;
 
       showThemedSnackBar(
@@ -78,6 +82,29 @@ class EditorNavigationHelper {
         accentColor: Theme.of(context).colorScheme.error,
         duration: const Duration(seconds: 3),
       );
+    } finally {
+      _dismissDialog(dialogShown, dialogContext, context);
+      _isOpeningDocument = false;
+    }
+  }
+
+  static void _dismissDialog(
+    bool dialogShown,
+    BuildContext? dialogContext,
+    BuildContext fallbackContext,
+  ) {
+    if (!dialogShown) return;
+
+    if (dialogContext != null && dialogContext.mounted) {
+      Navigator.of(dialogContext).pop();
+      return;
+    }
+
+    if (fallbackContext.mounted) {
+      final navigator = Navigator.of(fallbackContext, rootNavigator: true);
+      if (navigator.canPop()) {
+        navigator.pop();
+      }
     }
   }
 }

--- a/lib/widgets/themed_feedback.dart
+++ b/lib/widgets/themed_feedback.dart
@@ -4,7 +4,7 @@ import '../utils/app_style.dart';
 
 class ThemedProgressDialog extends StatelessWidget {
   final String title;
-  final String message;
+  final String? message;
   final String? label;
   final IconData icon;
   final Color? iconColor;
@@ -12,7 +12,7 @@ class ThemedProgressDialog extends StatelessWidget {
   const ThemedProgressDialog({
     super.key,
     required this.title,
-    required this.message,
+    this.message,
     this.label,
     this.icon = Icons.hourglass_top_rounded,
     this.iconColor,
@@ -108,15 +108,17 @@ class ThemedProgressDialog extends StatelessWidget {
                     ),
                   ),
                 ],
-                const SizedBox(height: 14),
-                Text(
-                  message,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    height: 1.45,
-                    color: colorScheme.onSurfaceVariant,
+                if (message != null && message!.trim().isNotEmpty) ...[
+                  const SizedBox(height: 14),
+                  Text(
+                    message!,
+                    textAlign: TextAlign.center,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      height: 1.45,
+                      color: colorScheme.onSurfaceVariant,
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),


### PR DESCRIPTION
### Motivation
- Prevent the editor from getting stuck on the "正在初始化文档" dialog after repeatedly opening/closing documents. 
- Remove redundant small helper text and filename from the initialization dialog to simplify the UI. 
- Fix PDF export where inline markdown (and headings with trailing `##`) were incorrectly rendered as `$1`. 
- Provide a new appearance option to customize the home page top-left title (default `汐`).

### Description
- Harden editor open flow by adding a concurrent-open guard, capturing the dialog BuildContext for reliable dismissal, adding timeouts to warm-up/preload tasks, and centralizing dialog dismissal logic; simplified the init dialog to only show the main title (files: `lib/utils/editor_navigation_helper.dart`, `lib/widgets/themed_feedback.dart`).
- Fix PDF export parsing by adjusting the heading regex to accept trailing `#` and replacing naive `replaceAll` uses with `replaceAllMapped` extracting capture groups to avoid literal `$1` replacements, and ensure inline markdown is stripped safely (file: `lib/services/export_service.dart`).
- Add a persistent setting `homeTitleText` with getter and setter to `SettingsProvider`, and expose a new UI control under Settings → 外观 to edit/save the home title; Home tab now displays the configured title instead of the hardcoded app name (files: `lib/providers/settings_provider.dart`, `lib/screens/settings/appearance_settings_screen.dart`, `lib/screens/main/tabs/home_tab.dart`).
- Make `ThemedProgressDialog.message` optional and only render the small text when non-empty to remove the redundant helper line.

### Testing
- Ran repository sanity check `git diff --check` which reported no issues. (success)
- Attempted to run `dart format` but the Dart/Flutter tooling is not available in this environment, so formatting/analysis were not executed. (skipped)
- `flutter analyze` was not run for the same reason (skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbefa2968483218166636ab8bc0ef3)