### PR TITLE
Improve blockquote inline editing behavior

### DIFF
--- a/lib/widgets/webview_markdown_preview.dart
+++ b/lib/widgets/webview_markdown_preview.dart
@@ -674,6 +674,15 @@ $body
     return { md: (best || innerText), index: bestIndex };
   }
 
+  function _setBlockSource(el, fallbackText) {
+    if (!el) return;
+    var match = _findBlockMatch(fallbackText || el.innerText || el.textContent || '');
+    if (el.dataset) {
+      el.dataset.mdSrc = match.md || fallbackText || '';
+      el.dataset.mdBlockIndex = String(match.index);
+    }
+  }
+
   function _getBlockMd(innerText) {
     return _findBlockMatch(innerText).md;
   }
@@ -832,10 +841,14 @@ $body
       qNode = qNode.parentElement || qNode.parentNode;
     }
     if (outerBq) {
-      var qText = (outerBq.dataset && outerBq.dataset.mdSrc) || (outerBq.innerText||outerBq.textContent||'').trim();
-      var qMatch = _findBlockMatch(qText);
-      var qMd = qMatch.md;
-      var qKey = 'blocksrc:' + btoa(unescape(encodeURIComponent(qMd))) + ':' + qMatch.index;
+      var qMd = (outerBq.dataset && outerBq.dataset.mdSrc) || (outerBq.innerText||outerBq.textContent||'').trim();
+      var qIndex = outerBq.dataset && outerBq.dataset.mdBlockIndex ? parseInt(outerBq.dataset.mdBlockIndex, 10) : -1;
+      if (!qMd) {
+        var qMatch = _findBlockMatch((outerBq.innerText||outerBq.textContent||'').trim());
+        qMd = qMatch.md;
+        qIndex = qMatch.index;
+      }
+      var qKey = 'blocksrc:' + btoa(unescape(encodeURIComponent(qMd))) + ':' + qIndex;
       _startEdit(outerBq, qKey, qMd);
       return;
     }
@@ -847,10 +860,14 @@ $body
       el = el.parentElement || el.parentNode;
     }
     if (!el || el === document.body) return;
-    var innerText = (el.dataset && el.dataset.mdSrc) || (el.innerText||el.textContent||'').trim();
-    var blockMatch = _findBlockMatch(innerText);
-    var blockMd = blockMatch.md;
-    var blockKey = 'blocksrc:' + btoa(unescape(encodeURIComponent(blockMd))) + ':' + blockMatch.index;
+    var blockMd = (el.dataset && el.dataset.mdSrc) || (el.innerText||el.textContent||'').trim();
+    var blockIndex = el.dataset && el.dataset.mdBlockIndex ? parseInt(el.dataset.mdBlockIndex, 10) : -1;
+    if (!blockMd) {
+      var blockMatch = _findBlockMatch((el.innerText||el.textContent||'').trim());
+      blockMd = blockMatch.md;
+      blockIndex = blockMatch.index;
+    }
+    var blockKey = 'blocksrc:' + btoa(unescape(encodeURIComponent(blockMd))) + ':' + blockIndex;
     _startEdit(el, blockKey, blockMd);
   }
 
@@ -864,7 +881,7 @@ $body
   };
   document.querySelectorAll('blockquote').forEach(function(bq){
     var txt = bq.innerText || '';
-    bq.dataset.mdSrc = txt.trim();
+    _setBlockSource(bq, txt.trim());
     var m = txt.match(/^\\s*\\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\\]/i);
     if(m){
       var cfg = alertMap[m[1].toUpperCase()];
@@ -876,6 +893,9 @@ $body
           '<div>'+content.replace(/\\n/g,'<br>')+'</div>';
       }
     }
+  });
+  document.querySelectorAll('pre').forEach(function(pre){
+    _setBlockSource(pre, (pre.innerText || pre.textContent || '').trim());
   });
 
   // ── Unified click handler (links + checkboxes + single-tap edit) ─────


### PR DESCRIPTION
### Motivation
- Blockquote taps in the WebView preview opened a fuzzy plain-text edit instead of the original block-level Markdown, causing loss of `>` markers and nested/multi-line structure during editing.
- Make blockquote editing behave like code-block/table editing: open a block-level editor backed by the original Markdown source so edits preserve Markdown markers and structure.

### Description
- Added a `_setBlockSource` JS helper to cache the raw Markdown match and its block index onto each rendered block element via `dataset.mdSrc` and `dataset.mdBlockIndex` (file: `lib/widgets/webview_markdown_preview.dart`).
- Call `_setBlockSource` when initializing rendered `blockquote` and `pre` elements so their original Markdown source is preserved even if the HTML is transformed (e.g. GitHub-style alerts).
- Updated the single-tap edit handler to prefer the cached `dataset.mdSrc`/`mdBlockIndex` when constructing the `blocksrc:` edit key, and fall back to the existing fuzzy `_findBlockMatch` behavior when cached metadata is unavailable.
- Kept existing behavior for table/cell edits and preserved the fuzzy-match fallback to ensure robust matching when dataset metadata is missing.

### Testing
- Ran repository checks: `git diff --check` succeeded.
- Verified file changes and committed the update (`git commit`) successfully.
- Attempted to run Dart/Flutter tooling (`which flutter || which dart`) but the environment reported `no-flutter-dart`, so `dart format`, `flutter analyze`, and `flutter test` could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbf4cea6ac83219692e67311bf1374)