### PR TITLE
Fix history markdown navigation (prevent black screen when opening from History)

### DIFF
--- a/lib/screens/folder/components/file_tile.dart
+++ b/lib/screens/folder/components/file_tile.dart
@@ -29,6 +29,7 @@ class FileTile extends StatelessWidget {
     final isFile = entity is File;
     final name = entity.path.split(Platform.pathSeparator).last;
     final isImage = isFile && _isImage(name);
+    final isMarkdownFile = isFile && _isMarkdownDocument(name);
     final isPinned = source == FileSource.pinned;
     
     // 获取文件/文件夹信息 (日期/大小)
@@ -68,11 +69,17 @@ class FileTile extends StatelessWidget {
           borderRadius: BorderRadius.circular(16),
           onTap: () async {
             if (isFile) {
-              if (name.toLowerCase().endsWith('.md')) {
+              if (isMarkdownFile) {
                 final fileProvider = context.read<FileProvider>();
-                fileProvider.addToRecentFiles(entity.path);
+                final navigationContext =
+                    Navigator.of(context, rootNavigator: true).context;
+
+                if (source != FileSource.history) {
+                  await fileProvider.addToRecentFiles(entity.path);
+                }
+
                 await EditorNavigationHelper.openEditor(
-                  context,
+                  navigationContext,
                   entity.path,
                 );
               } else if (isImage) {
@@ -238,6 +245,13 @@ class FileTile extends StatelessWidget {
            lower.endsWith('.png') || 
            lower.endsWith('.gif') || 
            lower.endsWith('.webp');
+  }
+
+  bool _isMarkdownDocument(String name) {
+    final lower = name.toLowerCase();
+    return lower.endsWith('.md') ||
+        lower.endsWith('.markdown') ||
+        lower.endsWith('.txt');
   }
 
   String _formatSize(int bytes) {

--- a/test/widgets/file_tile_test.dart
+++ b/test/widgets/file_tile_test.dart
@@ -1,0 +1,99 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mdreader/providers/file_provider.dart';
+import 'package:mdreader/providers/plugin_provider.dart';
+import 'package:mdreader/providers/settings_provider.dart';
+import 'package:mdreader/screens/folder/components/file_tile.dart';
+import 'package:mdreader/services/file_service.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockFileService extends Mock implements FileService {}
+
+class FakePathProviderPlatform extends PathProviderPlatform {
+  final String tempPath;
+
+  FakePathProviderPlatform(this.tempPath);
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => tempPath;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => tempPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => tempPath;
+}
+
+void main() {
+  group('FileTile', () {
+    late Directory tempDir;
+    late File file;
+    late MockFileService mockFileService;
+    late FileProvider fileProvider;
+    late SettingsProvider settingsProvider;
+    late PluginProvider pluginProvider;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('file_tile_test');
+      PathProviderPlatform.instance = FakePathProviderPlatform(tempDir.path);
+      SharedPreferences.setMockInitialValues({});
+
+      file = File('${tempDir.path}/note.md');
+      await file.writeAsString('# History Note');
+
+      mockFileService = MockFileService();
+      when(() => mockFileService.hasPermissions()).thenAnswer((_) async => true);
+      when(() => mockFileService.isFileCached(any())).thenReturn(false);
+      when(() => mockFileService.preloadFile(any()))
+          .thenAnswer((_) async => '# History Note');
+      when(() => mockFileService.readFile(any()))
+          .thenAnswer((_) async => '# History Note');
+
+      fileProvider = FileProvider(fileService: mockFileService);
+      settingsProvider = SettingsProvider();
+      pluginProvider = PluginProvider();
+      await fileProvider.addToRecentFiles(file.path);
+    });
+
+    tearDown(() async {
+      try {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      } catch (_) {}
+    });
+
+    testWidgets('opens markdown files from history without getting stuck',
+        (tester) async {
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider.value(value: fileProvider),
+            ChangeNotifierProvider.value(value: settingsProvider),
+            ChangeNotifierProvider.value(value: pluginProvider),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: FileTile(
+                entity: file,
+                source: FileSource.history,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(FileTile));
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.text('note'), findsOneWidget);
+      expect(fileProvider.recentFiles.first, file.path);
+    });
+  });
+}


### PR DESCRIPTION
### Motivation
- Opening Markdown files from the `History` tab caused a black screen because the tile logic would mutate recent list / use the local navigator context and trigger a refresh that invalidated the current navigation context.  
- The app already opens Markdown quickly from Home/Quick Actions/My Files using a stable navigation flow; History should follow the same behavior.  
- Also unify detection of Markdown-like documents so `.markdown` and `.txt` are handled like `.md` files.

### Description
- Use a helper `_isMarkdownDocument` to treat `.md`, `.markdown`, and `.txt` consistently when deciding whether to open in the editor.  
- When tapping a markdown file in `FileTile`, obtain a stable root navigator context via `Navigator.of(context, rootNavigator: true).context` and pass that into `EditorNavigationHelper.openEditor`.  
- Avoid reordering / adding the entry to recent list when the source is `FileSource.history` so the history view does not refresh itself before navigation.  
- Add a widget test `test/widgets/file_tile_test.dart` that covers opening a markdown file from `FileSource.history` and verifies navigation and recent-list behavior.

### Testing
- Ran `git diff --check` to validate changes and created a commit for the fix (succeeded).  
- Added `test/widgets/file_tile_test.dart` to cover the history-open scenario (test added but not executed in this environment).  
- Attempts to run `dart format` and `flutter test` could not be executed here because `dart`/`flutter` are not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc010a33508321b186fecf7b657e3e)