### PR TITLE
紧凑化设置页：移除副标题并缩小间距与图标

### DIFF
--- a/lib/screens/main/tabs/settings_tab.dart
+++ b/lib/screens/main/tabs/settings_tab.dart
@@ -7,9 +7,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../../providers/settings_provider.dart';
 import '../../../providers/plugin_provider.dart';
-import '../../../utils/constants.dart';
 import '../../../utils/app_style.dart';
 import '../../settings/appearance_settings_screen.dart';
 import '../../settings/editor_settings_screen.dart';
@@ -25,92 +23,82 @@ class SettingsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       bottom: false,
-      child: Consumer<SettingsProvider>(
-        builder: (context, settings, child) {
-          return ListView(
-            padding: const EdgeInsets.all(20),
-            children: [
-              _buildSettingsHeader(context),
-              const SizedBox(height: 24),
-              
-              _buildSettingsItem(
+      child: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildSettingsHeader(context),
+          const SizedBox(height: 16),
+
+          _buildSettingsItem(
+            context,
+            icon: Icons.palette,
+            iconColor: Colors.purple,
+            title: '外观',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const AppearanceSettingsScreen()),
+            ),
+          ),
+
+          _buildSettingsItem(
+            context,
+            icon: Icons.edit,
+            iconColor: Colors.blue,
+            title: '编辑器',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const EditorSettingsScreen()),
+            ),
+          ),
+
+          _buildSettingsItem(
+            context,
+            icon: Icons.cloud_sync,
+            iconColor: Colors.teal,
+            title: '云同步',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const CloudSyncScreen()),
+            ),
+          ),
+
+          _buildSettingsItem(
+            context,
+            icon: Icons.folder,
+            iconColor: Colors.amber,
+            title: '存储',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const StorageSettingsScreen()),
+            ),
+          ),
+
+          Consumer<PluginProvider>(
+            builder: (context, _, child) {
+              return _buildSettingsItem(
                 context,
-                icon: Icons.palette,
-                iconColor: Colors.purple,
-                title: '外观',
-                subtitle: _getThemeModeText(settings.themeMode),
+                icon: Icons.extension,
+                iconColor: Colors.deepPurple,
+                title: '插件',
                 onTap: () => Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => const AppearanceSettingsScreen()),
+                  MaterialPageRoute(builder: (_) => const PluginSettingsScreen()),
                 ),
-              ),
-              
-              _buildSettingsItem(
-                context,
-                icon: Icons.edit,
-                iconColor: Colors.blue,
-                title: '编辑器',
-                subtitle: '字体大小: ${settings.fontSize.toInt()}',
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const EditorSettingsScreen()),
-                ),
-              ),
-              
-              _buildSettingsItem(
-                context,
-                icon: Icons.cloud_sync,
-                iconColor: Colors.teal,
-                title: '云同步',
-                subtitle: settings.webdavUrl.isNotEmpty ? '已配置' : '未配置',
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const CloudSyncScreen()),
-                ),
-              ),
-              
-              _buildSettingsItem(
-                context,
-                icon: Icons.folder,
-                iconColor: Colors.amber,
-                title: '存储',
-                subtitle: '管理工作区和缓存',
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const StorageSettingsScreen()),
-                ),
-              ),
-              
-              Consumer<PluginProvider>(
-                builder: (context, pluginProvider, child) {
-                  return _buildSettingsItem(
-                    context,
-                    icon: Icons.extension,
-                    iconColor: Colors.deepPurple,
-                    title: '插件',
-                    subtitle: '已安装 ${pluginProvider.installedCount} 个插件',
-                    onTap: () => Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (_) => const PluginSettingsScreen()),
-                    ),
-                  );
-                },
-              ),
-              
-              _buildSettingsItem(
-                context,
-                icon: Icons.info,
-                iconColor: Colors.cyan,
-                title: '关于',
-                subtitle: 'v${AppConstants.appVersion}',
-                onTap: () => Navigator.push(
-                  context,
-                  MaterialPageRoute(builder: (_) => const AboutScreen()),
-                ),
-              ),
-            ],
-          );
-        },
+              );
+            },
+          ),
+
+          _buildSettingsItem(
+            context,
+            icon: Icons.info,
+            iconColor: Colors.cyan,
+            title: '关于',
+            onTap: () => Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const AboutScreen()),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -159,14 +147,13 @@ class SettingsTab extends StatelessWidget {
     required IconData icon,
     required Color iconColor,
     required String title,
-    required String subtitle,
     required VoidCallback onTap,
   }) {
     final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Container(
-      margin: const EdgeInsets.only(bottom: 12),
+      margin: const EdgeInsets.only(bottom: 8),
       decoration: appStyle.surfaceDecoration(
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(14),
         color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
         border: appStyle.useBorderlessButtons
             ? null
@@ -177,44 +164,33 @@ class SettingsTab extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(14),
           onTap: onTap,
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
             child: Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.all(10),
+                  padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
                     color: iconColor.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(10),
                   ),
-                  child: Icon(icon, color: iconColor),
+                  child: Icon(icon, color: iconColor, size: 18),
                 ),
-                const SizedBox(width: 16),
+                const SizedBox(width: 12),
                 Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        title,
-                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                              fontWeight: FontWeight.w600,
-                            ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        subtitle,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                              color: Theme.of(context).colorScheme.outline,
-                            ),
-                      ),
-                    ],
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
                   ),
                 ),
                 Icon(
                   Icons.chevron_right,
                   color: Theme.of(context).colorScheme.outline,
+                  size: 18,
                 ),
               ],
             ),
@@ -222,16 +198,5 @@ class SettingsTab extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String _getThemeModeText(ThemeMode mode) {
-    switch (mode) {
-      case ThemeMode.system:
-        return '跟随系统';
-      case ThemeMode.light:
-        return '浅色模式';
-      case ThemeMode.dark:
-        return '深色模式';
-    }
   }
 }


### PR DESCRIPTION
### Motivation
- 让设置页更紧凑以提高信息密度，通过减小行高、缩小图标和取消每项副标题来减少视觉占用并提升可读性。

### Description
- 将设置项从双行（标题+副标题）改为单行仅保留主标题，并移除与主题/版本相关的副标题渲染与关联逻辑（删除 `subtitle` 参数与相关辅助函数）。
- 缩小整体列表与项间距（`ListView` padding 从 20 -> 16，项间距 `margin` 从 12 -> 8），并降低卡片圆角与内边距以减少行高（`borderRadius`、`padding` 与 `InkWell` 配置被收紧）。
- 缩小图标容器与图标尺寸（内边距 10 -> 8，图标尺寸 -> 18），并同步缩小右侧箭头尺寸，保留现有色彩/点击反馈样式；同时精简 `Consumer<PluginProvider>` 的回调参数命名。
- 清理了不再使用的导入（移除对 `SettingsProvider`/`AppConstants` 的直接依赖和主题文字转换函数），变更文件：`lib/screens/main/tabs/settings_tab.dart`。

### Testing
- 运行 `dart format lib/screens/main/tabs/settings_tab.dart` 无法完成，因为环境中缺少 `dart`（失败，错误：`dart: command not found`）。
- 运行 `flutter analyze lib/screens/main/tabs/settings_tab.dart` 无法完成，因为环境中缺少 `flutter`（失败，错误：`flutter: command not found`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1a5390b483298be2b2b79bc7f7b8)