### PR TITLE
feat: add global card opacity control in appearance settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,8 +138,8 @@ class MyApp extends StatelessWidget {
               Locale('en', 'US'),  // 英文
             ],
             locale: settings.locale,  // 使用动态语言设置
-            theme: _buildLightTheme(primaryColor, fontFamily, lightThemeIndex, settings.buttonStyleMode, pluginLightColors),  // 浅色主题
-            darkTheme: _buildDarkTheme(primaryColor, darkThemeIndex, fontFamily, settings.buttonStyleMode, pluginDarkColors),  // 深色主题
+            theme: _buildLightTheme(primaryColor, fontFamily, lightThemeIndex, settings.buttonStyleMode, settings.cardOpacity, pluginLightColors),  // 浅色主题
+            darkTheme: _buildDarkTheme(primaryColor, darkThemeIndex, fontFamily, settings.buttonStyleMode, settings.cardOpacity, pluginDarkColors),  // 深色主题
             themeMode: settings.themeMode,  // 主题模式（跟随系统/浅色/深色）
             home: const MainScreen(),  // 主页面
           );
@@ -158,6 +158,7 @@ class MyApp extends StatelessWidget {
     String? fontFamily,
     int lightThemeIndex,
     AppButtonStyleMode buttonStyleMode,
+    double cardOpacity,
     ThemeColors? pluginColors,
   ) {
     final scheme = AppConstants.lightThemeSchemes[lightThemeIndex];
@@ -181,6 +182,7 @@ class MyApp extends StatelessWidget {
       textSecondaryColor: scheme.textSecondary,
       fontFamily: fontFamily,
       buttonStyleMode: buttonStyleMode,
+      cardOpacity: cardOpacity,
     );
   }
 
@@ -195,6 +197,7 @@ class MyApp extends StatelessWidget {
     int darkThemeIndex,
     String? fontFamily,
     AppButtonStyleMode buttonStyleMode,
+    double cardOpacity,
     ThemeColors? pluginColors,
   ) {
     final scheme = AppConstants.darkThemeSchemes[darkThemeIndex];
@@ -218,6 +221,7 @@ class MyApp extends StatelessWidget {
       textSecondaryColor: scheme.textSecondary,
       fontFamily: fontFamily,
       buttonStyleMode: buttonStyleMode,
+      cardOpacity: cardOpacity,
     );
   }
 
@@ -229,12 +233,14 @@ class MyApp extends StatelessWidget {
     required Color textSecondaryColor,
     required String? fontFamily,
     required AppButtonStyleMode buttonStyleMode,
+    required double cardOpacity,
   }) {
     final appStyle = AppStyleTheme.resolve(
       brightness: brightness,
       colorScheme: colorScheme,
       textSecondary: textSecondaryColor,
       buttonStyleMode: buttonStyleMode,
+      cardOpacity: cardOpacity,
     );
 
     final buttonForeground = appStyle.useBorderlessButtons
@@ -257,7 +263,7 @@ class MyApp extends StatelessWidget {
         centerTitle: false,
       ),
       cardTheme: CardThemeData(
-        color: colorScheme.surface,
+        color: appStyle.cardSurfaceColor(colorScheme),
         elevation: appStyle.useBorderlessButtons ? 4 : 0,
         shadowColor: Colors.black.withValues(alpha: 0.14),
         shape: RoundedRectangleBorder(

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -111,6 +111,9 @@ class SettingsProvider extends ChangeNotifier {
 
   // ==================== 底栏设置 ====================
 
+  /// 卡片透明度（0.4–1.0）
+  double _cardOpacity = 0.72;
+
   /// 底部导航栏透明度（0.1–1.0）
   double _tabBarOpacity = 0.95;
 
@@ -203,6 +206,7 @@ class SettingsProvider extends ChangeNotifier {
   double get backgroundOverlayOpacity => _backgroundOverlayOpacity;
 
   bool get autoCheckUpdate => _autoCheckUpdate;
+  double get cardOpacity => _cardOpacity;
   double get tabBarOpacity => _tabBarOpacity;
 
   // 图标设置 Getters
@@ -341,6 +345,7 @@ class SettingsProvider extends ChangeNotifier {
     _autoCheckUpdate = prefs.getBool('auto_check_update') ?? true;
 
     // 底栏设置
+    _cardOpacity = prefs.getDouble('card_opacity') ?? 0.72;
     _tabBarOpacity = prefs.getDouble('tab_bar_opacity') ?? 0.95;
 
     // 图标设置
@@ -635,6 +640,14 @@ class SettingsProvider extends ChangeNotifier {
     _autoCheckUpdate = value;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('auto_check_update', value);
+    notifyListeners();
+  }
+
+  /// 设置卡片透明度
+  Future<void> setCardOpacity(double opacity) async {
+    _cardOpacity = opacity;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble('card_opacity', opacity);
     notifyListeners();
   }
 

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -93,6 +93,11 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
                 _buildSection('按钮风格', Icons.smart_button_outlined, [
                   _buildButtonStyleSelector(settings),
                 ]),
+                const SizedBox(height: 16),
+
+                _buildSection('卡片透明度', Icons.opacity_rounded, [
+                  _buildCardOpacitySlider(settings),
+                ]),
 
                 // 浅色主题方案（仅在浅色模式下显示）
                 if (settings.themeMode == ThemeMode.light) ...[
@@ -159,6 +164,31 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
     );
   }
 
+  Widget _buildCardOpacitySlider(SettingsProvider settings) {
+    return Row(
+      children: [
+        const Text('透明度'),
+        Expanded(
+          child: Slider(
+            value: settings.cardOpacity,
+            min: 0.4,
+            max: 1.0,
+            divisions: 12,
+            label: '${(settings.cardOpacity * 100).round()}%',
+            onChanged: (value) => settings.setCardOpacity(value),
+          ),
+        ),
+        SizedBox(
+          width: 44,
+          child: Text(
+            '${(settings.cardOpacity * 100).round()}%',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildTabBarOpacitySlider(SettingsProvider settings) {
     return Row(
       children: [
@@ -189,7 +219,7 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
       padding: const EdgeInsets.all(16),
       decoration: _appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.72),
+        color: _appStyle.cardSurfaceColor(Theme.of(context).colorScheme),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/utils/app_style.dart
+++ b/lib/utils/app_style.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 /// 应用按钮风格模式。
@@ -14,6 +16,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
   final Color strongSurface;
   final List<BoxShadow> surfaceShadow;
   final List<BoxShadow> prominentShadow;
+  final double cardOpacity;
 
   const AppStyleTheme({
     required this.buttonStyleMode,
@@ -22,6 +25,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
     required this.strongSurface,
     required this.surfaceShadow,
     required this.prominentShadow,
+    required this.cardOpacity,
   });
 
   bool get useBorderlessButtons => buttonStyleMode == AppButtonStyleMode.softShadow;
@@ -31,6 +35,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
     required ColorScheme colorScheme,
     required Color textSecondary,
     required AppButtonStyleMode buttonStyleMode,
+    required double cardOpacity,
   }) {
     final isDark = brightness == Brightness.dark;
     final outlineColor = textSecondary.withValues(
@@ -66,6 +71,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
               ),
             ]
           : const [],
+      cardOpacity: cardOpacity,
       prominentShadow: [
         BoxShadow(
           color: prominentColor,
@@ -87,6 +93,10 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
       return Theme.of(context).colorScheme.primary.withValues(alpha: useBorderlessButtons ? 0.12 : 0.10);
     }
     return useBorderlessButtons ? strongSurface : Colors.transparent;
+  }
+
+  Color cardSurfaceColor(ColorScheme colorScheme) {
+    return colorScheme.surface.withValues(alpha: cardOpacity);
   }
 
   BoxDecoration surfaceDecoration({
@@ -111,6 +121,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
     Color? strongSurface,
     List<BoxShadow>? surfaceShadow,
     List<BoxShadow>? prominentShadow,
+    double? cardOpacity,
   }) {
     return AppStyleTheme(
       buttonStyleMode: buttonStyleMode ?? this.buttonStyleMode,
@@ -119,6 +130,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
       strongSurface: strongSurface ?? this.strongSurface,
       surfaceShadow: surfaceShadow ?? this.surfaceShadow,
       prominentShadow: prominentShadow ?? this.prominentShadow,
+      cardOpacity: cardOpacity ?? this.cardOpacity,
     );
   }
 
@@ -132,6 +144,7 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
       strongSurface: Color.lerp(strongSurface, other.strongSurface, t) ?? strongSurface,
       surfaceShadow: t < 0.5 ? surfaceShadow : other.surfaceShadow,
       prominentShadow: t < 0.5 ? prominentShadow : other.prominentShadow,
+      cardOpacity: lerpDouble(cardOpacity, other.cardOpacity, t) ?? cardOpacity,
     );
   }
 }

--- a/lib/widgets/glass_card.dart
+++ b/lib/widgets/glass_card.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../providers/settings_provider.dart';
 
 class GlassCard extends StatelessWidget {
   final IconData icon;
@@ -22,10 +25,12 @@ class GlassCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cardOpacity = context.watch<SettingsProvider>().cardOpacity;
+
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        color: Theme.of(context).colorScheme.surface.withValues(alpha: cardOpacity),
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: Theme.of(context).dividerColor.withValues(alpha: 0.5),


### PR DESCRIPTION
### Motivation

- Provide a global, persisted "卡片透明度" setting so card-like surfaces follow the same appearance scope as button style and theme, and allow users to adjust card transparency app-wide.

### Description

- Add `_cardOpacity` (default `0.72`) to `SettingsProvider` with getter, loading from `SharedPreferences`, and `setCardOpacity(double)` to persist changes (file: `lib/providers/settings_provider.dart`).
- Expose `cardOpacity` into theme generation by extending `AppStyleTheme` with a `cardOpacity` field and `cardSurfaceColor()` helper, and pass `settings.cardOpacity` into theme builders in `lib/main.dart` so global `CardTheme` uses the configured opacity (files: `lib/utils/app_style.dart`, `lib/main.dart`).
- Add a new "卡片透明度" section and slider (`0.4`–`1.0`) in the appearance settings screen (`lib/screens/settings/appearance_settings_screen.dart`) that updates the setting live and shows percentage label.
- Make `GlassCard` consume the global value (`context.watch<SettingsProvider>().cardOpacity`) so common card components reflect the configured transparency (file: `lib/widgets/glass_card.dart`).

### Testing

- Ran `git diff --check` which succeeded. 
- Attempted to run `dart format` and `flutter --version` but the environment lacks `dart`/`flutter` binaries so formatting and Flutter tool checks could not be executed. 
- No automated Flutter widget/integration tests were run in this environment due to missing toolchain.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc1e3dc34c83299a18c0b2876fcd3b)