### PR TITLE
优化历史/我的文件搜索样式并将编辑器搜索改为浮层

### DIFF
--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -1306,27 +1306,17 @@ class _EditorScreenState extends State<EditorScreen>
                   onSave: _saveFile,
                   onMore: _showMoreMenu,
                 ),
-                AnimatedSwitcher(
-                  duration: const Duration(milliseconds: 180),
-                  transitionBuilder: (child, animation) => FadeTransition(
-                    opacity: animation,
-                    child: SizeTransition(
-                      sizeFactor: animation,
-                      axisAlignment: -1,
-                      child: child,
-                    ),
-                  ),
-                  child: _showSearchBar
-                      ? KeyedSubtree(
-                          key: const ValueKey('inline-search'),
-                          child: _buildInlineSearch(),
-                        )
-                      : const SizedBox.shrink(key: ValueKey('inline-search-off')),
-                ),
                 Expanded(
                   child: Stack(
                     children: [
                       Positioned.fill(child: _buildContent()),
+                      if (_showSearchBar)
+                        Positioned(
+                          top: 10,
+                          left: 12,
+                          right: 12,
+                          child: _buildInlineSearch(),
+                        ),
                       // Toolbar floats at the bottom of the content area
                       if (!_isLoading &&
                           _error == null &&
@@ -1401,17 +1391,25 @@ class _EditorScreenState extends State<EditorScreen>
     final showCandidates =
         _showSearchCandidates && _searchController.text.trim().isNotEmpty;
 
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 0, 12, 8),
+    return Material(
+      color: Colors.transparent,
       child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
           Container(
             decoration: BoxDecoration(
-              color: theme.colorScheme.surface.withValues(alpha: 0.95),
-              borderRadius: BorderRadius.circular(14),
+              color: theme.colorScheme.surface.withValues(alpha: 0.97),
+              borderRadius: BorderRadius.circular(16),
               border: Border.all(
-                color: theme.colorScheme.outline.withValues(alpha: 0.2),
+                color: theme.colorScheme.outline.withValues(alpha: 0.22),
               ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.12),
+                  blurRadius: 16,
+                  offset: const Offset(0, 8),
+                ),
+              ],
             ),
             child: TextField(
               controller: _searchController,
@@ -1422,6 +1420,7 @@ class _EditorScreenState extends State<EditorScreen>
               decoration: InputDecoration(
                 hintText: '搜索内容...',
                 border: InputBorder.none,
+                contentPadding: const EdgeInsets.symmetric(vertical: 14),
                 prefixIcon: const Icon(Icons.search),
                 suffixIcon: IconButton(
                   tooltip: '关闭搜索',

--- a/lib/screens/folder/components/folder_browser_header.dart
+++ b/lib/screens/folder/components/folder_browser_header.dart
@@ -114,6 +114,8 @@ class FolderBrowserHeader extends StatelessWidget {
   }
 
   Widget _buildSearchHeader(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
+    final colorScheme = Theme.of(context).colorScheme;
     return Container(
       padding: const EdgeInsets.fromLTRB(8, 8, 16, 8),
       child: Row(
@@ -126,26 +128,38 @@ class FolderBrowserHeader extends StatelessWidget {
           const SizedBox(width: 12),
           Expanded(
             child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
+              height: 44,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              decoration: appStyle.surfaceDecoration(
                 borderRadius: BorderRadius.circular(12),
-                color: Theme.of(context).colorScheme.surface,
-                prominent: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
-                border: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons
+                color: colorScheme.surface.withValues(alpha: 0.5),
+                prominent: appStyle.useBorderlessButtons,
+                border: appStyle.useBorderlessButtons
                     ? null
                     : Border.all(
-                        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+                        color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
                       ),
               ),
-              child: TextField(
-                controller: searchController,
-                autofocus: true,
-                decoration: const InputDecoration(
-                  hintText: '搜索文件...',
-                  border: InputBorder.none,
-                  icon: Icon(Icons.search),
+              child: Center(
+                child: TextField(
+                  controller: searchController,
+                  autofocus: true,
+                  decoration: InputDecoration(
+                    hintText: '搜索文件...',
+                    border: InputBorder.none,
+                    isCollapsed: true,
+                    prefixIcon: Icon(
+                      Icons.search,
+                      size: 20,
+                      color: colorScheme.outline,
+                    ),
+                    prefixIconConstraints: const BoxConstraints(
+                      minWidth: 28,
+                      minHeight: 28,
+                    ),
+                  ),
+                  onChanged: onSearchChanged,
                 ),
-                onChanged: onSearchChanged,
               ),
             ),
           ),
@@ -160,31 +174,36 @@ class FolderBrowserHeader extends StatelessWidget {
     bool isActive = false,
   }) {
     final colorScheme = Theme.of(context).colorScheme;
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: onPressed,
-        child: Container(
-          padding: const EdgeInsets.all(10),
-          decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
-            borderRadius: BorderRadius.circular(12),
-            color: isActive
-                ? colorScheme.primary.withValues(alpha: 0.1)
-                : colorScheme.surface.withValues(alpha: 0.5),
-            prominent: isActive && Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
-            border: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons
-                ? null
-                : Border.all(
-                    color: isActive
-                        ? colorScheme.primary
-                        : Theme.of(context).dividerColor.withValues(alpha: 0.5),
-                  ),
-          ),
-          child: Icon(
-            icon, 
-            size: 20, 
-            color: isActive ? colorScheme.primary : null,
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onPressed,
+          child: Container(
+            alignment: Alignment.center,
+            decoration: appStyle.surfaceDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: isActive
+                  ? colorScheme.primary.withValues(alpha: 0.1)
+                  : colorScheme.surface.withValues(alpha: 0.5),
+              prominent: isActive && appStyle.useBorderlessButtons,
+              border: appStyle.useBorderlessButtons
+                  ? null
+                  : Border.all(
+                      color: isActive
+                          ? colorScheme.primary
+                          : Theme.of(context).dividerColor.withValues(alpha: 0.5),
+                    ),
+            ),
+            child: Icon(
+              icon,
+              size: 20,
+              color: isActive ? colorScheme.primary : null,
+            ),
           ),
         ),
       ),
@@ -192,19 +211,24 @@ class FolderBrowserHeader extends StatelessWidget {
   }
 
   Widget _buildSortButton(BuildContext context) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () => _showSortMenu(context),
-        child: Container(
-          padding: const EdgeInsets.all(10),
-          decoration: Theme.of(context).extension<AppStyleTheme>()!.surfaceDecoration(
-            borderRadius: BorderRadius.circular(12),
-            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.5),
-            prominent: Theme.of(context).extension<AppStyleTheme>()!.useBorderlessButtons,
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: () => _showSortMenu(context),
+          child: Container(
+            alignment: Alignment.center,
+            decoration: appStyle.surfaceDecoration(
+              borderRadius: BorderRadius.circular(12),
+              color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.5),
+              prominent: appStyle.useBorderlessButtons,
+            ),
+            child: const Icon(Icons.sort, size: 20),
           ),
-          child: const Icon(Icons.sort, size: 20),
         ),
       ),
     );

--- a/lib/screens/main/tabs/history_tab.dart
+++ b/lib/screens/main/tabs/history_tab.dart
@@ -72,6 +72,10 @@ class _HistoryTabState extends State<HistoryTab> {
           IconButton(
             icon: const Icon(Icons.delete_outline),
             tooltip: '清空历史',
+            style: IconButton.styleFrom(
+              backgroundColor: Colors.transparent,
+              surfaceTintColor: Colors.transparent,
+            ),
             onPressed: _showClearHistoryDialog,
           ),
           const SizedBox(width: 8),


### PR DESCRIPTION
### Motivation

- 统一应用内搜索/控制按钮的视觉样式，移除历史页删除按钮的意外底色，并让“我的文件”搜索态与左侧返回按钮在尺寸与底色风格上保持一致，以改善视觉一致性和可读性。
- 将编辑器内的搜索框从占位式布局改为悬浮层，避免挤压编辑/预览区域并提供独立圆角矩形与阴影以突出浮层交互。

### Description

- 将历史标签页的“清空历史”按钮改为透明背景以移除默认底色（`lib/screens/main/tabs/history_tab.dart`）。
- 调整“我的文件”搜索态头部：将搜索框高度规范为 `44`，使用统一的 `surface` 半透明背景与边框，改为简洁的前缀图标并使搜索框与左侧返回按钮视觉一致；并将顶部操作按钮（搜索/图片/排序/新建）统一为 44px 的方形居中按钮（`lib/screens/folder/components/folder_browser_header.dart`）。
- 将编辑器的内联搜索从原先的布局节点改为覆盖在内容区之上的悬浮控件（使用 `Positioned`），并为其增加圆角矩形边框、稍强的半透明 surface 背景与阴影，保证在包含 WebView 的预览区域上方浮层显示而不改变页面主布局（`lib/screens/editor_screen.dart`）。
- 涉及文件：
  - `lib/screens/main/tabs/history_tab.dart`
  - `lib/screens/folder/components/folder_browser_header.dart`
  - `lib/screens/editor_screen.dart`

### Testing

- 无法在当前环境执行格式化/静态检查，尝试运行 `dart format` 和 `flutter format` 均因环境中缺少 `dart`/`flutter` 而失败.
- 已检查变更差异并提交：运行 `git diff -- <files>` 成功显示变更，且已通过 `git commit` 提交本次修改。
- 未运行任何自动化单元/集成测试或 CI（本次环境中未执行 `flutter test`/CI 流水线）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2220ef008329a544295f1f45df13)