### PR TITLE
fix: add missing Provider import in HomeTab

### DIFF
--- a/lib/screens/main/tabs/home_tab.dart
+++ b/lib/screens/main/tabs/home_tab.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../../../providers/file_provider.dart';
 import '../../../../providers/settings_provider.dart';
 import '../../../../utils/file_actions.dart';


### PR DESCRIPTION
### Motivation
- 修复编译错误: 在 `lib/screens/main/tabs/home_tab.dart` 中使用 `Consumer<SettingsProvider>` 时找不到 `Consumer`，导致构建失败。

### Description
- 在 `lib/screens/main/tabs/home_tab.dart` 顶部加入 `import 'package:provider/provider.dart';` 以提供 `Consumer` 等 API。

### Testing
- 尝试运行 `flutter analyze lib/screens/main/tabs/home_tab.dart` 进行静态分析，但当前环境缺少 `flutter`（`flutter: command not found`），因此无法在此环境完成自动化分析。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcd4376be48329a21a48ddd3cae5eb)