### PR TITLE
统一“卡片透明度”在 GlassCard 的作用域与全局样式行为

### DIFF
--- a/lib/widgets/glass_card.dart
+++ b/lib/widgets/glass_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
-import '../providers/settings_provider.dart';
+import '../utils/app_style.dart';
 
 class GlassCard extends StatelessWidget {
   final IconData icon;
@@ -25,23 +24,12 @@ class GlassCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cardOpacity = context.watch<SettingsProvider>().cardOpacity;
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
 
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: cardOpacity),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.05),
-            blurRadius: 10,
-            offset: const Offset(0, 2),
-          ),
-        ],
       ),
       child: Material(
         color: Colors.transparent,


### PR DESCRIPTION
### Motivation
- 使“外观-卡片透明度”的生效范围与“按钮风格”保持一致，避免 `GlassCard` 使用独立的透明度/边框/阴影逻辑。

### Description
- 将 `GlassCard` 从直接读取 `SettingsProvider.cardOpacity` 的实现替换为使用 `AppStyleTheme.surfaceDecoration(...)` 来构建卡片装饰。 
- 移除了对 `provider/settings_provider.dart` 的直接依赖并改为导入 `app_style.dart`，改动集中在 `lib/widgets/glass_card.dart`。 
- 这样卡片的透明度、边框与阴影由主题扩展(`AppStyleTheme`)统一控制，从而与其它使用该扩展的卡片保持一致。 

### Testing
- 尝试运行 `dart format lib/widgets/glass_card.dart`，但环境中缺少 `dart` 命令，未能执行（失败）。
- 尝试运行 `flutter analyze lib/widgets/glass_card.dart`，但环境中缺少 `flutter` 命令，未能执行（失败）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcd6beae9483298199d80d9608c8e2)