### PR TITLE
Centralize surface opacity with `AppStyle.scaledSurfaceColor` and apply to UI surfaces

### DIFF
--- a/lib/screens/editor/components/editor_header.dart
+++ b/lib/screens/editor/components/editor_header.dart
@@ -76,7 +76,10 @@ class EditorHeader extends StatelessWidget {
         padding: const EdgeInsets.all(10),
         decoration: appStyle.surfaceDecoration(
           borderRadius: BorderRadius.circular(12),
-          color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.82),
+          color: appStyle.scaledSurfaceColor(
+            Theme.of(context).colorScheme,
+            alpha: 0.82,
+          ),
           prominent: appStyle.useBorderlessButtons,
         ),
         child: Icon(
@@ -109,7 +112,7 @@ class EditorHeader extends StatelessWidget {
             padding: const EdgeInsets.all(12),
             decoration: appStyle.surfaceDecoration(
               borderRadius: BorderRadius.circular(12),
-              color: colorScheme.surface.withValues(alpha: 0.82),
+              color: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.82),
               prominent: appStyle.useBorderlessButtons,
             ),
             child: AnimatedSwitcher(

--- a/lib/screens/editor/components/fullscreen_preview_page.dart
+++ b/lib/screens/editor/components/fullscreen_preview_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import '../../../../providers/settings_provider.dart';
+import '../../../../utils/app_style.dart';
 import '../../../../utils/constants.dart';
 import '../../../../widgets/webview_markdown_preview.dart';
 import '../../../../services/export_service.dart';
@@ -203,6 +204,7 @@ class _FullscreenPreviewPageState extends State<FullscreenPreviewPage> {
 
   @override
   Widget build(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.transparent,
@@ -211,7 +213,10 @@ class _FullscreenPreviewPageState extends State<FullscreenPreviewPage> {
           icon: Container(
             padding: const EdgeInsets.all(8),
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+              color: appStyle.scaledSurfaceColor(
+                Theme.of(context).colorScheme,
+                alpha: 0.8,
+              ),
               borderRadius: BorderRadius.circular(12),
               border: Border.all(
                 color: Theme.of(context).dividerColor.withValues(alpha: 0.5),

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -10,6 +10,7 @@ import '../providers/file_provider.dart';
 import '../providers/settings_provider.dart';
 import '../utils/constants.dart';
 import '../utils/editor_navigation_helper.dart';
+import '../utils/app_style.dart';
 import '../widgets/markdown_toolbar.dart';
 import '../widgets/webview_markdown_preview.dart';
 import '../widgets/particle_effect_widget.dart';
@@ -1375,6 +1376,7 @@ class _EditorScreenState extends State<EditorScreen>
     }
 
     final theme = Theme.of(context);
+    final appStyle = theme.extension<AppStyleTheme>()!;
     final displayMatches = _searchMatches.take(5).toList(growable: false);
     final showCandidates =
         _showSearchCandidates && _searchController.text.trim().isNotEmpty;
@@ -1386,7 +1388,10 @@ class _EditorScreenState extends State<EditorScreen>
         children: [
           Container(
             decoration: BoxDecoration(
-              color: theme.colorScheme.surface.withValues(alpha: 0.97),
+              color: appStyle.scaledSurfaceColor(
+                theme.colorScheme,
+                alpha: 0.97,
+              ),
               borderRadius: BorderRadius.circular(16),
               border: Border.all(
                 color: theme.colorScheme.outline.withValues(alpha: 0.22),
@@ -1442,7 +1447,10 @@ class _EditorScreenState extends State<EditorScreen>
                       width: double.infinity,
                       constraints: const BoxConstraints(maxHeight: 220),
                       decoration: BoxDecoration(
-                        color: theme.colorScheme.surface.withValues(alpha: 0.98),
+                        color: appStyle.scaledSurfaceColor(
+                          theme.colorScheme,
+                          alpha: 0.98,
+                        ),
                         borderRadius: BorderRadius.circular(14),
                         border: Border.all(
                           color: theme.colorScheme.outline.withValues(alpha: 0.2),

--- a/lib/screens/folder/components/file_tile.dart
+++ b/lib/screens/folder/components/file_tile.dart
@@ -52,7 +52,10 @@ class FileTile extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 8),
       decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.7,
+        ),
         border: appStyle.useBorderlessButtons
             ? null
             : Border.all(

--- a/lib/screens/folder/components/folder_browser_header.dart
+++ b/lib/screens/folder/components/folder_browser_header.dart
@@ -132,7 +132,7 @@ class FolderBrowserHeader extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 12),
               decoration: appStyle.surfaceDecoration(
                 borderRadius: BorderRadius.circular(12),
-                color: colorScheme.surface.withValues(alpha: 0.5),
+                color: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.5),
                 prominent: appStyle.useBorderlessButtons,
                 border: appStyle.useBorderlessButtons
                     ? null
@@ -189,7 +189,7 @@ class FolderBrowserHeader extends StatelessWidget {
               borderRadius: BorderRadius.circular(12),
               color: isActive
                   ? colorScheme.primary.withValues(alpha: 0.1)
-                  : colorScheme.surface.withValues(alpha: 0.5),
+                  : appStyle.scaledSurfaceColor(colorScheme, alpha: 0.5),
               prominent: isActive && appStyle.useBorderlessButtons,
               border: appStyle.useBorderlessButtons
                   ? null
@@ -224,7 +224,10 @@ class FolderBrowserHeader extends StatelessWidget {
             alignment: Alignment.center,
             decoration: appStyle.surfaceDecoration(
               borderRadius: BorderRadius.circular(12),
-              color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.5),
+              color: appStyle.scaledSurfaceColor(
+                Theme.of(context).colorScheme,
+                alpha: 0.5,
+              ),
               prominent: appStyle.useBorderlessButtons,
             ),
             child: const Icon(Icons.sort, size: 20),

--- a/lib/screens/main/components/quick_actions.dart
+++ b/lib/screens/main/components/quick_actions.dart
@@ -257,7 +257,10 @@ class QuickActions extends StatelessWidget {
           padding: const EdgeInsets.all(12),
           decoration: appStyle.surfaceDecoration(
             borderRadius: BorderRadius.circular(16),
-            color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+            color: appStyle.scaledSurfaceColor(
+              Theme.of(context).colorScheme,
+              alpha: 0.8,
+            ),
             border: appStyle.useBorderlessButtons
                 ? null
                 : Border.all(

--- a/lib/screens/main/tabs/history_tab.dart
+++ b/lib/screens/main/tabs/history_tab.dart
@@ -118,7 +118,10 @@ class _HistoryTabState extends State<HistoryTab> {
     return Container(
       decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(12),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.8,
+        ),
         border: appStyle.useBorderlessButtons
             ? null
             : Border.all(

--- a/lib/screens/main/tabs/settings_tab.dart
+++ b/lib/screens/main/tabs/settings_tab.dart
@@ -130,7 +130,10 @@ class SettingsTab extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 8),
       decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(14),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.7,
+        ),
         border: appStyle.useBorderlessButtons
             ? null
             : Border.all(

--- a/lib/screens/settings/about_screen.dart
+++ b/lib/screens/settings/about_screen.dart
@@ -140,7 +140,10 @@ class _AboutScreenState extends State<AboutScreen> {
       padding: const EdgeInsets.all(16),
       decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.7,
+        ),
         border: appStyle.useBorderlessButtons
             ? null
             : Border.all(

--- a/lib/screens/settings/editor_settings_screen.dart
+++ b/lib/screens/settings/editor_settings_screen.dart
@@ -56,7 +56,10 @@ class EditorSettingsScreen extends StatelessWidget {
       padding: const EdgeInsets.all(16),
       decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.7,
+        ),
         border: appStyle.useBorderlessButtons
             ? null
             : Border.all(

--- a/lib/screens/settings/storage_settings_screen.dart
+++ b/lib/screens/settings/storage_settings_screen.dart
@@ -113,7 +113,10 @@ class _StorageSettingsScreenState extends State<StorageSettingsScreen> {
       padding: const EdgeInsets.all(16),
       decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.7,
+        ),
         border: appStyle.useBorderlessButtons
             ? null
             : Border.all(

--- a/lib/utils/app_style.dart
+++ b/lib/utils/app_style.dart
@@ -102,6 +102,13 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
     return cardSurface;
   }
 
+  /// 为局部 surface 颜色提供统一的透明度缩放：
+  /// 传入的 [alpha] 会与全局卡片透明度相乘，确保“卡片透明度”全局生效。
+  Color scaledSurfaceColor(ColorScheme colorScheme, {double alpha = 1}) {
+    final effectiveAlpha = (cardOpacity * alpha).clamp(0.0, 1.0);
+    return colorScheme.surface.withValues(alpha: effectiveAlpha);
+  }
+
   BoxDecoration surfaceDecoration({
     required BorderRadius borderRadius,
     Color? color,

--- a/lib/widgets/glass_card.dart
+++ b/lib/widgets/glass_card.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
-import '../providers/settings_provider.dart';
+import '../utils/app_style.dart';
 
 class GlassCard extends StatelessWidget {
   final IconData icon;
@@ -25,23 +24,12 @@ class GlassCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cardOpacity = context.watch<SettingsProvider>().cardOpacity;
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
 
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: cardOpacity),
+      decoration: appStyle.surfaceDecoration(
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Theme.of(context).dividerColor.withValues(alpha: 0.5),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.05),
-            blurRadius: 10,
-            offset: const Offset(0, 2),
-          ),
-        ],
       ),
       child: Material(
         color: Colors.transparent,

--- a/lib/widgets/markdown_toolbar.dart
+++ b/lib/widgets/markdown_toolbar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import '../services/my_files_service.dart';
+import '../utils/app_style.dart';
 
 /// Markdown editing toolbar with beautiful gradient buttons
 class MarkdownToolbar extends StatelessWidget {
@@ -27,13 +28,17 @@ class MarkdownToolbar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
     final showCustomUndoRedo =
         undoController == null && onUndo != null && onRedo != null;
 
     return Container(
       height: 56,
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surface.withValues(alpha: 0.95),
+        color: appStyle.scaledSurfaceColor(
+          Theme.of(context).colorScheme,
+          alpha: 0.95,
+        ),
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
         boxShadow: [
           BoxShadow(


### PR DESCRIPTION
### Motivation
- Ensure consistent card/surface transparency across the app by centralizing surface alpha calculation.  
- Reduce duplicated calls to `Theme.of(context).colorScheme.surface.withValues(alpha: ...)` and make card opacity respect the global `cardOpacity` setting.  
- Leverage the existing `AppStyleTheme` extension to unify surface decorations and simplify widget code.  

### Description
- Added `scaledSurfaceColor(ColorScheme, {double alpha = 1})` to `AppStyleTheme` that multiplies provided `alpha` with the global `cardOpacity` and returns a surfaced color.  
- Replaced many instances of `colorScheme.surface.withValues(alpha: X)` with `appStyle.scaledSurfaceColor(colorScheme, alpha: X)` across multiple screens and components including editor header, fullscreen preview, editor screen, folder/file lists, main quick actions, history/settings tabs, storage/editor settings, and markdown toolbar.  
- Updated `GlassCard` to use `appStyle.surfaceDecoration` and removed direct `SettingsProvider` dependency and manual decoration properties.  
- Added imports of `app_style.dart` where needed and used the `AppStyleTheme` extension (`Theme.of(context).extension<AppStyleTheme>()!`) to access decoration helpers.  

### Testing
- Ran static analysis with `flutter analyze` and there were no new analyzer errors.  
- Executed the test suite with `flutter test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcd6beae9483298199d80d9608c8e2)