### PR TITLE
feat: 全局统一卡片透明度到所有 surface 与按钮

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -200,7 +200,7 @@ class MyApp extends StatelessWidget {
         : Colors.white;
     final buttonBackground = appStyle.useBorderlessButtons
         ? appStyle.strongSurface
-        : colorScheme.primary;
+        : colorScheme.primary.withValues(alpha: appStyle.cardOpacity);
 
     ThemeData theme = ThemeData(
       useMaterial3: true,
@@ -209,7 +209,7 @@ class MyApp extends StatelessWidget {
       scaffoldBackgroundColor: backgroundColor,
       extensions: [appStyle],
       appBarTheme: AppBarTheme(
-        backgroundColor: colorScheme.surface,
+        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.92),
         foregroundColor: textColor,
         elevation: 0,
         centerTitle: false,
@@ -303,24 +303,26 @@ class MyApp extends StatelessWidget {
         thickness: 1,
       ),
       dialogTheme: DialogThemeData(
-        backgroundColor: colorScheme.surface,
+        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
       ),
       bottomSheetTheme: BottomSheetThemeData(
-        backgroundColor: colorScheme.surface,
+        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
         ),
       ),
       popupMenuTheme: PopupMenuThemeData(
-        color: colorScheme.surface,
+        color: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         elevation: appStyle.useBorderlessButtons ? 0 : 8,
       ),
       dropdownMenuTheme: DropdownMenuThemeData(
         textStyle: TextStyle(color: textColor),
         menuStyle: MenuStyle(
-          backgroundColor: WidgetStatePropertyAll(colorScheme.surface),
+          backgroundColor: WidgetStatePropertyAll(
+            appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
+          ),
           shape: WidgetStatePropertyAll(
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
@@ -331,7 +333,7 @@ class MyApp extends StatelessWidget {
       snackBarTheme: SnackBarThemeData(
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        backgroundColor: colorScheme.surface,
+        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
         contentTextStyle: TextStyle(color: textColor),
       ),
       textTheme: TextTheme(

--- a/lib/utils/app_style.dart
+++ b/lib/utils/app_style.dart
@@ -40,6 +40,8 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
     required double cardOpacity,
   }) {
     final isDark = brightness == Brightness.dark;
+    final mutedAlpha = (cardOpacity * (isDark ? 0.82 : 0.76)).clamp(0.0, 1.0);
+    final strongAlpha = (cardOpacity * (isDark ? 0.94 : 0.90)).clamp(0.0, 1.0);
     final outlineColor = textSecondary.withValues(
       alpha: buttonStyleMode == AppButtonStyleMode.softShadow ? (isDark ? 0.0 : 0.04) : (isDark ? 0.28 : 0.16),
     );
@@ -49,14 +51,8 @@ class AppStyleTheme extends ThemeExtension<AppStyleTheme> {
     return AppStyleTheme(
       buttonStyleMode: buttonStyleMode,
       outlineColor: outlineColor,
-      mutedSurface: Color.alphaBlend(
-        colorScheme.primary.withValues(alpha: isDark ? 0.08 : 0.04),
-        colorScheme.surface,
-      ),
-      strongSurface: Color.alphaBlend(
-        Colors.white.withValues(alpha: isDark ? 0.03 : 0.7),
-        colorScheme.surface,
-      ),
+      mutedSurface: colorScheme.surface.withValues(alpha: mutedAlpha),
+      strongSurface: colorScheme.surface.withValues(alpha: strongAlpha),
       cardSurface: colorScheme.surface.withValues(alpha: cardOpacity),
       surfaceShadow: buttonStyleMode == AppButtonStyleMode.softShadow
           ? [


### PR DESCRIPTION
### Motivation
- 让“外观 → 卡片透明度 (`cardOpacity`)”成为应用中所有卡片/面板/按钮类元素的唯一透明度来源，避免透明度设置仅影响设置页的局部卡片。

### Description
- 将 `AppStyleTheme` 中的 `mutedSurface` 与 `strongSurface` 改为基于 `cardOpacity` 计算的透明 `surface`，通过 `colorScheme.surface.withValues(alpha: ...)` 统一控制。
- 将主题中若干使用 `colorScheme.surface` 的组件背景（包括 `AppBar`、`Dialog`、`BottomSheet`、`PopupMenu`、`DropdownMenu` 的 `menuStyle` 背景与 `SnackBar`）替换为 `appStyle.scaledSurfaceColor(colorScheme, alpha: ...)`，将这些面板纳入全局透明度策略。
- 在经典按钮模式下把主按钮背景设置为 `colorScheme.primary.withValues(alpha: appStyle.cardOpacity)`，使填充/提升按钮与浮动按钮的视觉透明度也由同一设置控制。

### Testing
- 已通过差异检查查看并确认修改内容（`git diff` 输出），差异与预期一致且无语法明显错误。
- 在当前环境尝试运行 `dart format` 与 `flutter format` 以做代码格式化，但因环境缺少 `dart`/`flutter` 可执行文件而失败。
- 未运行单元测试或集成测试，因执行环境不包含 Flutter/Dart 运行时与测试工具。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bced8aca3c83298673834972f091c4)