### PR TITLE
fix: 让卡片透明度设置全局控制所有 surface 卡片

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -187,9 +187,13 @@ class MyApp extends StatelessWidget {
     required AppButtonStyleMode buttonStyleMode,
     required double cardOpacity,
   }) {
+    final effectiveColorScheme = _applyGlobalCardOpacity(
+      colorScheme,
+      cardOpacity,
+    );
     final appStyle = AppStyleTheme.resolve(
       brightness: brightness,
-      colorScheme: colorScheme,
+      colorScheme: effectiveColorScheme,
       textSecondary: textSecondaryColor,
       buttonStyleMode: buttonStyleMode,
       cardOpacity: cardOpacity,
@@ -200,22 +204,22 @@ class MyApp extends StatelessWidget {
         : Colors.white;
     final buttonBackground = appStyle.useBorderlessButtons
         ? appStyle.strongSurface
-        : colorScheme.primary.withValues(alpha: appStyle.cardOpacity);
+        : effectiveColorScheme.primary.withValues(alpha: appStyle.cardOpacity);
 
     ThemeData theme = ThemeData(
       useMaterial3: true,
       brightness: brightness,
-      colorScheme: colorScheme,
+      colorScheme: effectiveColorScheme,
       scaffoldBackgroundColor: backgroundColor,
       extensions: [appStyle],
       appBarTheme: AppBarTheme(
-        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.92),
+        backgroundColor: appStyle.scaledSurfaceColor(effectiveColorScheme, alpha: 0.92),
         foregroundColor: textColor,
         elevation: 0,
         centerTitle: false,
       ),
       cardTheme: CardThemeData(
-        color: appStyle.cardSurfaceColor(colorScheme),
+        color: appStyle.cardSurfaceColor(effectiveColorScheme),
         elevation: appStyle.useBorderlessButtons ? 4 : 0,
         shadowColor: Colors.black.withValues(alpha: 0.14),
         shape: RoundedRectangleBorder(
@@ -303,17 +307,17 @@ class MyApp extends StatelessWidget {
         thickness: 1,
       ),
       dialogTheme: DialogThemeData(
-        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
+        backgroundColor: appStyle.scaledSurfaceColor(effectiveColorScheme, alpha: 0.95),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
       ),
       bottomSheetTheme: BottomSheetThemeData(
-        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
+        backgroundColor: appStyle.scaledSurfaceColor(effectiveColorScheme, alpha: 0.95),
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
         ),
       ),
       popupMenuTheme: PopupMenuThemeData(
-        color: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
+        color: appStyle.scaledSurfaceColor(effectiveColorScheme, alpha: 0.95),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         elevation: appStyle.useBorderlessButtons ? 0 : 8,
       ),
@@ -321,7 +325,7 @@ class MyApp extends StatelessWidget {
         textStyle: TextStyle(color: textColor),
         menuStyle: MenuStyle(
           backgroundColor: WidgetStatePropertyAll(
-            appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
+            appStyle.scaledSurfaceColor(effectiveColorScheme, alpha: 0.95),
           ),
           shape: WidgetStatePropertyAll(
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
@@ -333,7 +337,7 @@ class MyApp extends StatelessWidget {
       snackBarTheme: SnackBarThemeData(
         behavior: SnackBarBehavior.floating,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-        backgroundColor: appStyle.scaledSurfaceColor(colorScheme, alpha: 0.95),
+        backgroundColor: appStyle.scaledSurfaceColor(effectiveColorScheme, alpha: 0.95),
         contentTextStyle: TextStyle(color: textColor),
       ),
       textTheme: TextTheme(
@@ -353,6 +357,24 @@ class MyApp extends StatelessWidget {
     }
 
     return theme;
+  }
+
+  ColorScheme _applyGlobalCardOpacity(
+    ColorScheme colorScheme,
+    double cardOpacity,
+  ) {
+    Color applyOpacity(Color color) => color.withValues(alpha: cardOpacity);
+
+    return colorScheme.copyWith(
+      surface: applyOpacity(colorScheme.surface),
+      surfaceDim: applyOpacity(colorScheme.surfaceDim),
+      surfaceBright: applyOpacity(colorScheme.surfaceBright),
+      surfaceContainerLowest: applyOpacity(colorScheme.surfaceContainerLowest),
+      surfaceContainerLow: applyOpacity(colorScheme.surfaceContainerLow),
+      surfaceContainer: applyOpacity(colorScheme.surfaceContainer),
+      surfaceContainerHigh: applyOpacity(colorScheme.surfaceContainerHigh),
+      surfaceContainerHighest: applyOpacity(colorScheme.surfaceContainerHighest),
+    );
   }
 
   OutlineInputBorder _buildInputBorder(AppStyleTheme appStyle, Color color) {


### PR DESCRIPTION
### Motivation
- 现有“外观 - 卡片透明底”设置只在部分设置页卡片生效，无法作为软件全局的卡片透明度来源。 
- 目标是让该设置成为所有使用 surface 色系的卡片/按钮容器的唯一透明度决定来源，覆盖文件/文件夹卡片、按钮卡片等。 

### Description
- 在 `lib/main.dart` 的 `_buildTheme` 中引入 `effectiveColorScheme`，由新方法 `_applyGlobalCardOpacity` 根据 `cardOpacity` 对 surface 系列颜色统一缩放。 
- 将 `AppStyleTheme.resolve(...)` 和 `ThemeData.colorScheme` 改为使用 `effectiveColorScheme`，确保主题扩展与 Material 组件使用相同的透明度来源。 
- 将依赖 surface 颜色的场景（包括 `appBar`、`dialog`、`bottomSheet`、`popupMenu`、`dropdownMenu`、`snackBar`、`cardTheme` 及按钮背景等）改为基于 `effectiveColorScheme` 计算。 
- 新增私有方法 `ColorScheme _applyGlobalCardOpacity(ColorScheme, double)` 来逐项设置 `surface`、`surfaceDim`、`surfaceBright`、`surfaceContainer*` 等字段的透明度。 

### Testing
- 尝试运行 `dart format lib/main.dart` 进行代码格式化，因环境缺少 `dart/flutter` 命令而失败，未能在当前环境完成自动格式化或编译验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcf354db9c832982c69e93a593f021)