### PR TITLE
Provide cardOpacity to AppStyleTheme.resolve in themed feedback widgets

### DIFF
--- a/lib/widgets/themed_feedback.dart
+++ b/lib/widgets/themed_feedback.dart
@@ -28,6 +28,7 @@ class ThemedProgressDialog extends StatelessWidget {
           colorScheme: colorScheme,
           textSecondary: colorScheme.onSurfaceVariant,
           buttonStyleMode: AppButtonStyleMode.classic,
+          cardOpacity: 0.72,
         );
     final accent = iconColor ?? colorScheme.primary;
     final surface = Color.alphaBlend(
@@ -144,6 +145,7 @@ void showThemedSnackBar(
         colorScheme: colorScheme,
         textSecondary: colorScheme.onSurfaceVariant,
         buttonStyleMode: AppButtonStyleMode.classic,
+        cardOpacity: 0.72,
       );
   final accent = accentColor ?? colorScheme.primary;
 


### PR DESCRIPTION
### Motivation
- Fix the build-time error caused by missing required named parameter `cardOpacity` in fallback `AppStyleTheme.resolve(...)` calls used by themed feedback widgets.

### Description
- Add `cardOpacity: 0.72` to both fallback `AppStyleTheme.resolve(...)` invocations in `lib/widgets/themed_feedback.dart` (used by `ThemedProgressDialog` and `showThemedSnackBar`) to match the app's default card opacity.

### Testing
- Attempted to run `flutter analyze lib/widgets/themed_feedback.dart`, but the command failed in this environment because `flutter` is not installed; no other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf6ee565f08329b57d22ca6520ff6d)