### PR TITLE
fix: use official Milkdown Crepe initialization

### DIFF
--- a/web/milkdown/src/main.js
+++ b/web/milkdown/src/main.js
@@ -2,7 +2,7 @@ import {
   commandsCtx,
   editorViewCtx,
 } from '@milkdown/core';
-import { CrepeBuilder } from '@milkdown/crepe/builder';
+import { Crepe } from '@milkdown/crepe';
 import { automd } from '@milkdown/plugin-automd';
 import { clipboard } from '@milkdown/plugin-clipboard';
 import { cursor } from '@milkdown/plugin-cursor';
@@ -14,9 +14,6 @@ import { indent } from '@milkdown/plugin-indent';
 import { math } from '@milkdown/plugin-math';
 import { trailing } from '@milkdown/plugin-trailing';
 import { upload, uploadConfig } from '@milkdown/plugin-upload';
-import { blockEdit } from '@milkdown/crepe/feature/block-edit';
-import { toolbar } from '@milkdown/crepe/feature/toolbar';
-import { linkTooltip } from '@milkdown/crepe/feature/link-tooltip';
 import {
   insertHrCommand,
   createCodeBlockCommand,
@@ -551,7 +548,7 @@ const updateActiveMarkdownHints = () => {
 };
 
 const createEditor = async () => {
-  const crepe = new CrepeBuilder({
+  const crepe = new Crepe({
     root: app,
     defaultValue: currentMarkdown,
   });
@@ -582,14 +579,6 @@ const createEditor = async () => {
     .use(math)
     .use(cursor)
     .use(upload);
-
-  blockEdit(editor, {
-    advancedGroup: {
-      image: null,
-    },
-  });
-  toolbar(editor);
-  linkTooltip(editor);
 
   editorInstance = await editor.create();
   contextMenuElement = createContextMenuElement();


### PR DESCRIPTION
### Motivation
- 修复打开编辑器后出现的错误提示："Milkdown 初始化失败：MilkdownError: Context \"FeaturesCtx\" not found"，这是因为仓库中使用了自制的 Crepe/feature 装配方式导致缺失官方上下文注入。
- 按 Milkdown 官方建议优先使用官方入口初始化，移除自制特性接入以避免重复或不正确的 Context 注入。

### Description
- 将 `web/milkdown/src/main.js` 中的 `CrepeBuilder` 引入替换为官方 `Crepe` 入口并改用 `new Crepe({...})` 进行初始化。
- 删除对 `@milkdown/crepe/feature/block-edit`、`toolbar`、`link-tooltip` 的自定义导入与手动调用，从而放弃自制的特性装配（包括此前对 `advancedGroup.image = null` 的调整）。
- 保留并沿用现有的插件配置：只读控制、`listener` 回调、`highlight` 配置与自定义 `upload` 处理器，改由官方 `Crepe` 的默认特性加载来初始化这些功能。
- 仅修改前端初始化逻辑，未改动编辑器业务接口或 Flutter bridge 协议代码。

### Testing
- 运行 `node --check web/milkdown/src/main.js` 校验语法，结果通过（成功）。
- 在当前环境尝试运行 `cd web/milkdown && npm run build` 进行构建验证，但构建未能在此环境完成，因为 `vite` 在 PATH 中不可用／运行时环境中缺少可执行的构建工具，构建因此失败。
- 已在本地安装依赖 (`npm install` 在本环境创建了 `node_modules` 目录)，并且对变更文件进行了静态检查。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0e960ee14832184d69d7718743193)