### PR TITLE
feat: 为外观背景与编辑器背景新增亮度调节滑条

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -90,11 +90,17 @@ class SettingsProvider extends ChangeNotifier {
   /// 模糊效果强度（0-30）
   double _backgroundBlur = 10.0;
 
+  /// 主背景亮度（0.2-1.8，1.0 为原始亮度）
+  double _backgroundBrightness = 1.0;
+
   /// 编辑器背景是否启用模糊
   bool _editorBackgroundBlurEnabled = false;
 
   /// 编辑器背景模糊强度（0-30）
   double _editorBackgroundBlur = 10.0;
+
+  /// 编辑器背景亮度（0.2-1.8，1.0 为原始亮度）
+  double _editorBackgroundBrightness = 1.0;
 
   /// 遮罩透明度（0-1，保留但当前 UI 未使用）
   double _backgroundOverlayOpacity = 0.5;
@@ -213,8 +219,10 @@ class SettingsProvider extends ChangeNotifier {
   String? get editorBackgroundImagePath => _editorBackgroundImagePath;
   String get backgroundEffect => _backgroundEffect;
   double get backgroundBlur => _backgroundBlur;
+  double get backgroundBrightness => _backgroundBrightness;
   bool get editorBackgroundBlurEnabled => _editorBackgroundBlurEnabled;
   double get editorBackgroundBlur => _editorBackgroundBlur;
+  double get editorBackgroundBrightness => _editorBackgroundBrightness;
   double get backgroundOverlayOpacity => _backgroundOverlayOpacity;
 
   bool get autoCheckUpdate => _autoCheckUpdate;
@@ -339,8 +347,11 @@ class SettingsProvider extends ChangeNotifier {
     _editorBackgroundImagePath = prefs.getString('editor_background_image_path');
     _backgroundEffect = prefs.getString('background_effect') ?? 'none';
     _backgroundBlur = prefs.getDouble('background_blur') ?? 10.0;
+    _backgroundBrightness = prefs.getDouble('background_brightness') ?? 1.0;
     _editorBackgroundBlurEnabled = prefs.getBool('editor_background_blur_enabled') ?? false;
     _editorBackgroundBlur = prefs.getDouble('editor_background_blur') ?? 10.0;
+    _editorBackgroundBrightness =
+        prefs.getDouble('editor_background_brightness') ?? 1.0;
     _backgroundOverlayOpacity =
         prefs.getDouble('background_overlay_opacity') ?? 0.5;
 
@@ -596,6 +607,14 @@ class SettingsProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 设置背景亮度
+  Future<void> setBackgroundBrightness(double brightness) async {
+    _backgroundBrightness = brightness;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble('background_brightness', brightness);
+    notifyListeners();
+  }
+
   /// 设置编辑器背景模糊开关
   Future<void> setEditorBackgroundBlurEnabled(bool enabled) async {
     _editorBackgroundBlurEnabled = enabled;
@@ -609,6 +628,14 @@ class SettingsProvider extends ChangeNotifier {
     _editorBackgroundBlur = blur;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setDouble('editor_background_blur', blur);
+    notifyListeners();
+  }
+
+  /// 设置编辑器背景亮度
+  Future<void> setEditorBackgroundBrightness(double brightness) async {
+    _editorBackgroundBrightness = brightness;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setDouble('editor_background_brightness', brightness);
     notifyListeners();
   }
 

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -1397,6 +1397,16 @@ class _EditorScreenState extends State<EditorScreen>
       height: double.infinity,
     );
 
+    imageLayer = ColorFiltered(
+      colorFilter: ColorFilter.matrix([
+        settings.editorBackgroundBrightness, 0, 0, 0, 0,
+        0, settings.editorBackgroundBrightness, 0, 0, 0,
+        0, 0, settings.editorBackgroundBrightness, 0, 0,
+        0, 0, 0, 1, 0,
+      ]),
+      child: imageLayer,
+    );
+
     if (settings.editorBackgroundBlurEnabled) {
       imageLayer = ImageFiltered(
         imageFilter: ImageFilter.blur(

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -761,6 +761,23 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
               ),
             ],
           ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('亮度'),
+              Expanded(
+                child: Slider(
+                  value: settings.backgroundBrightness,
+                  min: 0.2,
+                  max: 1.8,
+                  divisions: 32,
+                  label: '${(settings.backgroundBrightness * 100).round()}%',
+                  onChanged: (value) => settings.setBackgroundBrightness(value),
+                ),
+              ),
+              Text('${(settings.backgroundBrightness * 100).round()}%'),
+            ],
+          ),
           // 模糊强度滑块
           if (settings.backgroundEffect == 'blur') ...[
             const SizedBox(height: 8),
@@ -842,6 +859,26 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
                   settings.setEditorBackgroundBlurEnabled(value);
                 },
               ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('亮度'),
+              Expanded(
+                child: Slider(
+                  value: settings.editorBackgroundBrightness,
+                  min: 0.2,
+                  max: 1.8,
+                  divisions: 32,
+                  label:
+                      '${(settings.editorBackgroundBrightness * 100).round()}%',
+                  onChanged: (value) {
+                    settings.setEditorBackgroundBrightness(value);
+                  },
+                ),
+              ),
+              Text('${(settings.editorBackgroundBrightness * 100).round()}%'),
             ],
           ),
           if (settings.editorBackgroundBlurEnabled) ...[

--- a/lib/widgets/app_background.dart
+++ b/lib/widgets/app_background.dart
@@ -87,6 +87,16 @@ class AppBackground extends StatelessWidget {
           width: double.infinity,
           height: double.infinity,
         );
+
+        bgImage = ColorFiltered(
+          colorFilter: ColorFilter.matrix([
+            settings.backgroundBrightness, 0, 0, 0, 0,
+            0, settings.backgroundBrightness, 0, 0, 0,
+            0, 0, settings.backgroundBrightness, 0, 0,
+            0, 0, 0, 1, 0,
+          ]),
+          child: bgImage,
+        );
         
         // Apply blur effect
         if (settings.backgroundEffect == 'blur') {

--- a/test/providers/settings_provider_test.dart
+++ b/test/providers/settings_provider_test.dart
@@ -97,5 +97,17 @@ void main() {
       expect(prefs.getBool('editor_background_blur_enabled'), isTrue);
       expect(prefs.getDouble('editor_background_blur'), 18.0);
     });
+
+    test('背景亮度设置应更新并持久化', () async {
+      await provider.setBackgroundBrightness(1.25);
+      await provider.setEditorBackgroundBrightness(0.8);
+
+      expect(provider.backgroundBrightness, 1.25);
+      expect(provider.editorBackgroundBrightness, 0.8);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getDouble('background_brightness'), 1.25);
+      expect(prefs.getDouble('editor_background_brightness'), 0.8);
+    });
   });
 }


### PR DESCRIPTION
### Motivation

- 为所有外观-背景相关设置增加亮度调节选项，以便用户可以对主背景和编辑器背景图片进行亮度微调（20%–180%）。
- 使亮度设置可持久化并能在渲染层实时生效，提升背景图片个性化控制能力。

### Description

- 在 `SettingsProvider` 中新增状态与持久化字段 `background_brightness` 和 `editor_background_brightness`，并添加对应的 getters 与方法 `setBackgroundBrightness`、`setEditorBackgroundBrightness`，以及初始化时的读取逻辑（默认 `1.0`）。
- 在主背景渲染 `lib/widgets/app_background.dart` 中对背景图片使用 `ColorFiltered`（`ColorFilter.matrix`）应用 `settings.backgroundBrightness`，从而实现亮度调整。
- 在编辑器背景层 `lib/screens/editor_screen.dart` 对编辑器背景图片同样使用 `ColorFiltered` 应用 `settings.editorBackgroundBrightness`。
- 在设置页面 `lib/screens/settings/appearance_settings_screen.dart` 为「背景」和「编辑器背景图片」分别新增亮度 `Slider`（范围 `0.2`–`1.8`，分辨率 32），并显示实时百分比；同时增加相应 UI 文本显示。 
- 新增单元测试 `test/providers/settings_provider_test.dart` 中关于亮度设置的断言，用于验证内存状态与 `SharedPreferences` 的持久化写入。

### Testing

- 执行静态检查：`git diff --check` 通过（未发现冲突或空白错误）。
- 在当前环境无法运行 Dart/Flutter 工具链，因此未执行 `dart format` 或 `flutter test`，相应命令返回 `dart: command not found` / `flutter: command not found`。 
- 已添加并提交单元测试 `test/providers/settings_provider_test.dart`（验证 `setBackgroundBrightness` 与 `setEditorBackgroundBrightness` 的内存更新与持久化），但该测试在当前环境中未运行。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11d8c00a483298295b49443b5ec89)