### PR TITLE
fix(milkdown): sanitize image src when adjacent markdown headings/list/quote markers present

### DIFF
--- a/web/milkdown/src/main.js
+++ b/web/milkdown/src/main.js
@@ -608,18 +608,30 @@ const sanitizeImageSource = (src) => {
   if (typeof src !== 'string') return '';
   const trimmed = src.trim();
   if (!trimmed) return '';
-  const markdownTitleMatch = trimmed.match(/^(\S+)\s+["'“”][\s\S]*["'“”]$/);
+  const firstLine = trimmed.split(/\r?\n/u, 1)[0]?.trim() || '';
+  if (!firstLine) return '';
+  const sanitizedLine = firstLine;
+  if (
+    /\s+#{1,6}\s+\S/u.test(sanitizedLine)
+    || /\s+>\s+\S/u.test(sanitizedLine)
+    || /\s+[-*+]\s+\S/u.test(sanitizedLine)
+    || /\s+\d+\.\s+\S/u.test(sanitizedLine)
+  ) {
+    const firstToken = sanitizedLine.split(/\s+/u, 1)[0]?.trim() || '';
+    if (firstToken) return firstToken;
+  }
+  const markdownTitleMatch = sanitizedLine.match(/^(\S+)\s+["'“”][\s\S]*["'“”]$/);
   if (markdownTitleMatch && markdownTitleMatch[1]) {
     return markdownTitleMatch[1].trim();
   }
-  const firstSpace = trimmed.indexOf(' ');
+  const firstSpace = sanitizedLine.indexOf(' ');
   if (firstSpace > 0) {
-    const suffix = trimmed.slice(firstSpace + 1).trim();
+    const suffix = sanitizedLine.slice(firstSpace + 1).trim();
     if (suffix.startsWith('"') || suffix.startsWith("'") || suffix.startsWith('“')) {
-      return trimmed.slice(0, firstSpace).trim();
+      return sanitizedLine.slice(0, firstSpace).trim();
     }
   }
-  return trimmed;
+  return sanitizedLine;
 };
 
 const decodeFileUriPath = (value) => {


### PR DESCRIPTION
### Motivation
- Images inserted between two valid ATX headings could become broken because `src` was parsed including trailing lines or markdown tokens, producing an invalid local path.
- The sanitizer previously operated on the full `src` string which could include newline-joined markdown blocks and cause Proxied `file://` resolution to fail.

### Description
- Harden `sanitizeImageSource` in `web/milkdown/src/main.js` to first extract and normalize the first line of the `src` before further parsing.
- Add heuristic checks to detect suspicious trailing markdown suffixes (ATX headings, block quotes, list markers, ordered list markers) and, when detected, return only the first token as the image path to avoid using the malformed suffix.
- Preserve existing title-style parsing (e.g. `url "title"`) but apply it to the normalized single-line input rather than the full multi-line string.
- Updated usages within `sanitizeImageSource` to operate on the sanitized first line (`sanitizedLine`) to avoid cross-line misparsing.

### Testing
- Ran `npm run build` in `web/milkdown` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3706651bc83219242f69b16245407)