### PR TITLE
Mark generated Milkdown asset as linguist-generated in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Keep GitHub language stats focused on Flutter/Dart sources.
+# This file is a built runtime artifact generated from web/milkdown sources.
+assets/milkdown_web/index.html linguist-generated=true


### PR DESCRIPTION
### Motivation
- Prevent the built Milkdown runtime artifact from affecting GitHub language statistics by marking it as generated and preserve existing LF normalization rules in `.gitattributes`.

### Description
- Add a `linguist-generated=true` entry for `assets/milkdown_web/index.html` in `.gitattributes` and include explanatory comments about the purpose of the entry.

### Testing
- No automated tests were run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c1a493f88329a1c35284d7311886)