### PR TITLE
feat(settings): 添加"开放源代码许可"页面并接入关于页

### DIFF
--- a/lib/screens/settings/about_screen.dart
+++ b/lib/screens/settings/about_screen.dart
@@ -13,6 +13,7 @@ import '../../services/update_service.dart';
 import '../../widgets/app_background.dart';
 import '../../providers/settings_provider.dart';
 import '../../utils/app_style.dart';
+import 'open_source_licenses_screen.dart';
 
 class AboutScreen extends StatefulWidget {
   const AboutScreen({super.key});
@@ -46,6 +47,17 @@ class _AboutScreenState extends State<AboutScreen> {
                 title: '开源地址',
                 subtitle: AppConstants.githubUrl,
                 onTap: () => _launchUrl(AppConstants.githubUrl),
+              ),
+              _buildLinkTile(
+                icon: Icons.description_outlined,
+                title: '开放源代码许可',
+                subtitle: '查看项目使用的开源依赖及许可信息',
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const OpenSourceLicensesScreen(),
+                  ),
+                ),
               ),
             ]),
             const SizedBox(height: 16),

--- a/lib/screens/settings/open_source_licenses_screen.dart
+++ b/lib/screens/settings/open_source_licenses_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../../utils/app_style.dart';
+import '../../widgets/app_background.dart';
+
+class OpenSourceLicensesScreen extends StatelessWidget {
+  const OpenSourceLicensesScreen({super.key});
+
+  static const List<_LicenseItem> _flutterDependencies = [
+    _LicenseItem('flutter', 'BSD-3-Clause', 'https://github.com/flutter/flutter'),
+    _LicenseItem('cupertino_icons', 'MIT', 'https://github.com/flutter/cupertino_icons'),
+    _LicenseItem('flutter_markdown_plus', 'BSD-3-Clause', 'https://github.com/fzyzcjy/flutter_markdown'),
+    _LicenseItem('flutter_inappwebview', 'Apache-2.0', 'https://github.com/pichillilorenzo/flutter_inappwebview'),
+    _LicenseItem('flutter_highlight', 'MIT', 'https://github.com/git-touch/highlight.dart'),
+    _LicenseItem('http', 'BSD-3-Clause', 'https://github.com/dart-lang/http'),
+    _LicenseItem('file_picker', 'Apache-2.0', 'https://github.com/miguelpruivo/flutter_file_picker'),
+    _LicenseItem('permission_handler', 'MIT', 'https://github.com/Baseflow/flutter-permission-handler'),
+    _LicenseItem('path_provider', 'BSD-3-Clause', 'https://github.com/flutter/packages/tree/main/packages/path_provider/path_provider'),
+    _LicenseItem('provider', 'MIT', 'https://github.com/rrousselGit/provider'),
+    _LicenseItem('shared_preferences', 'BSD-3-Clause', 'https://github.com/flutter/packages/tree/main/packages/shared_preferences/shared_preferences'),
+    _LicenseItem('flutter_secure_storage', 'BSD-3-Clause', 'https://github.com/juliansteenbakker/flutter_secure_storage'),
+    _LicenseItem('url_launcher', 'BSD-3-Clause', 'https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher'),
+    _LicenseItem('markdown', 'BSD-3-Clause', 'https://github.com/dart-lang/tools/tree/main/pkgs/markdown'),
+    _LicenseItem('webdav_client', 'MIT', 'https://github.com/xpwu/webdav_client'),
+    _LicenseItem('ftpconnect', 'MIT', 'https://github.com/robertoszek/ftpconnect'),
+    _LicenseItem('share_plus', 'BSD-3-Clause', 'https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus'),
+    _LicenseItem('receive_sharing_intent', 'MIT', 'https://github.com/KasemJaffer/receive_sharing_intent'),
+    _LicenseItem('google_fonts', 'Apache-2.0', 'https://github.com/material-foundation/flutter-packages/tree/main/packages/google_fonts/google_fonts'),
+    _LicenseItem('archive', 'BSD-3-Clause', 'https://github.com/brendan-duncan/archive'),
+    _LicenseItem('pdf', 'Apache-2.0', 'https://github.com/DavBfr/dart_pdf'),
+    _LicenseItem('printing', 'Apache-2.0', 'https://github.com/DavBfr/dart_pdf/tree/master/printing'),
+    _LicenseItem('screenshot', 'MIT', 'https://github.com/SachinGanesh/screenshot'),
+    _LicenseItem('package_info_plus', 'BSD-3-Clause', 'https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus'),
+    _LicenseItem('mime', 'BSD-3-Clause', 'https://github.com/dart-lang/tools/tree/main/pkgs/mime'),
+  ];
+
+  static const List<_LicenseItem> _webDependencies = [
+    _LicenseItem('@milkdown/core', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/crepe', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-automd', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-clipboard', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-cursor', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-emoji', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-highlight', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-history', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-indent', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-listener', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-math', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-trailing', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/plugin-upload', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/preset-commonmark', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/preset-gfm', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/theme-nord', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('@milkdown/utils', 'MIT', 'https://github.com/Milkdown/milkdown'),
+    _LicenseItem('katex', 'MIT', 'https://github.com/KaTeX/KaTeX'),
+    _LicenseItem('prismjs', 'MIT', 'https://github.com/PrismJS/prism'),
+    _LicenseItem('refractor', 'MIT', 'https://github.com/wooorm/refractor'),
+    _LicenseItem('vite', 'MIT', 'https://github.com/vitejs/vite'),
+    _LicenseItem('vite-plugin-singlefile', 'MIT', 'https://github.com/richardtallent/vite-plugin-singlefile'),
+  ];
+
+  static const List<_LicenseItem> _fontAssets = [
+    _LicenseItem('Noto Sans SC', 'SIL Open Font License 1.1', 'https://fonts.google.com/noto/specimen/Noto+Sans+SC'),
+    _LicenseItem('JetBrains Mono', 'SIL Open Font License 1.1', 'https://www.jetbrains.com/lp/mono/'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final appStyle = Theme.of(context).extension<AppStyleTheme>()!;
+
+    return AppBackground(
+      wrapWithSafeArea: false,
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          title: const Text('开放源代码许可'),
+          centerTitle: true,
+        ),
+        body: ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            Text(
+              '本应用使用了多个开源项目。以下列表根据仓库依赖配置整理（pubspec.yaml、web/milkdown/package.json）。详细条款请以各项目仓库内 LICENSE 文件为准。',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            _buildSection(context, appStyle, 'Flutter / Dart 依赖', _flutterDependencies),
+            const SizedBox(height: 16),
+            _buildSection(context, appStyle, 'Web 编辑器依赖（Milkdown）', _webDependencies),
+            const SizedBox(height: 16),
+            _buildSection(context, appStyle, '字体资源', _fontAssets),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSection(
+    BuildContext context,
+    AppStyleTheme appStyle,
+    String title,
+    List<_LicenseItem> items,
+  ) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: appStyle.surfaceDecoration(
+        borderRadius: BorderRadius.circular(16),
+        color: appStyle.scaledSurfaceColor(Theme.of(context).colorScheme, alpha: 0.7),
+        border: appStyle.useBorderlessButtons
+            ? null
+            : Border.all(color: Theme.of(context).dividerColor.withValues(alpha: 0.5)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 12),
+          for (final item in items)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: SelectableText('${item.name} · ${item.license}\n${item.url}'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LicenseItem {
+  final String name;
+  final String license;
+  final String url;
+
+  const _LicenseItem(this.name, this.license, this.url);
+}

--- a/lib/screens/settings/open_source_licenses_screen.dart
+++ b/lib/screens/settings/open_source_licenses_screen.dart
@@ -1,4 +1,11 @@
+// ============================================================================
+// 开放源代码许可页面
+//
+// 展示应用所使用的开源依赖及对应许可信息
+// ============================================================================
+
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../utils/app_style.dart';
 import '../../widgets/app_background.dart';
@@ -8,6 +15,7 @@ class OpenSourceLicensesScreen extends StatelessWidget {
 
   static const List<_LicenseItem> _flutterDependencies = [
     _LicenseItem('flutter', 'BSD-3-Clause', 'https://github.com/flutter/flutter'),
+    _LicenseItem('flutter_localizations', 'BSD-3-Clause', 'https://github.com/flutter/flutter/tree/master/packages/flutter_localizations'),
     _LicenseItem('cupertino_icons', 'MIT', 'https://github.com/flutter/cupertino_icons'),
     _LicenseItem('flutter_markdown_plus', 'BSD-3-Clause', 'https://github.com/fzyzcjy/flutter_markdown'),
     _LicenseItem('flutter_inappwebview', 'Apache-2.0', 'https://github.com/pichillilorenzo/flutter_inappwebview'),
@@ -122,7 +130,30 @@ class OpenSourceLicensesScreen extends StatelessWidget {
           for (final item in items)
             Padding(
               padding: const EdgeInsets.only(bottom: 10),
-              child: SelectableText('${item.name} · ${item.license}\n${item.url}'),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  SelectableText(
+                    '${item.name} · ${item.license}',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  GestureDetector(
+                    onTap: () async {
+                      final uri = Uri.parse(item.url);
+                      if (await canLaunchUrl(uri)) {
+                        await launchUrl(uri, mode: LaunchMode.externalApplication);
+                      }
+                    },
+                    child: SelectableText(
+                      item.url,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context).colorScheme.primary,
+                            decoration: TextDecoration.underline,
+                          ),
+                    ),
+                  ),
+                ],
+              ),
             ),
         ],
       ),

--- a/test/screens/settings/about_screen_test.dart
+++ b/test/screens/settings/about_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mdreader/screens/settings/about_screen.dart';
+import 'package:mdreader/screens/settings/open_source_licenses_screen.dart';
 import 'package:mdreader/services/update_service.dart';
 import 'package:mdreader/providers/settings_provider.dart';
 import 'package:http/http.dart' as http;
@@ -126,5 +127,21 @@ void main() {
     // Tap it
     await tester.tap(updateButton);
     await tester.pump();
+  });
+
+  testWidgets('开放源代码许可 tile is present and navigates to OpenSourceLicensesScreen',
+      (WidgetTester tester) async {
+    await pumpAboutScreen(tester);
+    await tester.pumpAndSettle();
+
+    // The tile should be visible
+    expect(find.text('开放源代码许可'), findsOneWidget);
+
+    // Tap the tile to navigate
+    await tester.tap(find.text('开放源代码许可'));
+    await tester.pumpAndSettle();
+
+    // OpenSourceLicensesScreen should be pushed
+    expect(find.byType(OpenSourceLicensesScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
### Motivation
- 增加一个集中可见的"开放源代码许可"页面，便于用户查看应用所使用的开源库及对应许可信息。 
- 许可信息基于仓库的依赖配置生成，覆盖 Flutter/Dart 依赖、Web 编辑器（milkdown）依赖和内置字体资源。 
- 将该页面作为"设置 → 关于"中"链接"分组的一项，提升可访问性并与现有"开源地址/检查更新"功能并列。 

### Description
- 新增页面 `lib/screens/settings/open_source_licenses_screen.dart`，按"Flutter / Dart 依赖""Web 编辑器依赖（Milkdown）""字体资源"三组展示每个条目的库名、许可证类型与项目链接。
  - 文件头部添加与其他设置页面一致的标准 `// ===...` 注释块。
  - Flutter/Dart 依赖列表补充了此前遗漏的 `flutter_localizations` 条目。
  - 每个条目的项目链接现在可点击（通过 `url_launcher` 打开外部浏览器），并以带下划线的主题色文字渲染，同时保留文本选择功能。
- 在 `lib/screens/settings/about_screen.dart` 中加入 `open_source_licenses_screen.dart` 的导入并在"链接"分组新增"开放源代码许可"条目以支持页面跳转。
- 许可列表项来源为仓库文件：`pubspec.yaml`、`web/milkdown/package.json`，以及项目内置字体资产，页面正文注明以各项目 LICENSE 为准。

### Testing
- 在 `test/screens/settings/about_screen_test.dart` 中新增 widget 测试，验证"开放源代码许可"条目可见，且点击后正确跳转至 `OpenSourceLicensesScreen`。

------
<a href="https://chatgpt.com/codex/tasks/task_e_69d0fb9eb860832986945b6a30237313">Codex Task</a>